### PR TITLE
feat: trazer layout base (Header, navegação, Footer) para a main

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,0 +1,9 @@
+function Footer() {
+  return (
+    <footer>
+      © 2026 PassaAdiante - Todos os direitos reservados
+    </footer>
+  )
+}
+
+export default Footer

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,0 +1,38 @@
+import { Link } from 'react-router-dom'
+
+function Header() {
+  return (
+    <header className="header">
+      <nav className="menu">
+        <Link to="/" className="menu__logo">
+          <p>PassaAdiante</p>
+        </Link>
+
+        <ul className="menu__list">
+          <li className="menu__item">
+            <Link to="/" className="menu__link">Início</Link>
+          </li>
+          <li className="menu__item">
+            <Link to="/sobre-o-projeto" className="menu__link">Sobre</Link>
+          </li>
+          <li className="menu__item">
+            <Link to="/como-participar" className="menu__link">Como participar</Link>
+          </li>
+          <li className="menu__item">
+            <Link to="/catalogo" className="menu__link">Catálogo</Link>
+          </li>
+          <li className="menu__item">
+            <Link to="/contato" className="menu__link">Contato</Link>
+          </li>
+        </ul>
+
+        <div className="menu__actions">
+          <button type="button" className="btn btn--primary">Entrar</button>
+          <button type="button" className="btn btn--secondary">Cadastre-se</button>
+        </div>
+      </nav>
+    </header>
+  )
+}
+
+export default Header

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,0 +1,17 @@
+import { Outlet } from 'react-router-dom'
+import Header from './Header.jsx'
+import Footer from './Footer.jsx'
+
+function Layout() {
+  return (
+    <>
+      <Header />
+      <main>
+        <Outlet />
+      </main>
+      <Footer />
+    </>
+  )
+}
+
+export default Layout

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -1,4 +1,5 @@
 import { Routes, Route } from 'react-router-dom'
+import Layout from './components/Layout.jsx'
 import Home from './pages/Home.jsx'
 import SobreOProjeto from './pages/SobreOProjeto.jsx'
 import Catalogo from './pages/Catalogo.jsx'
@@ -8,11 +9,13 @@ import Contato from './pages/Contato.jsx'
 function AppRoutes() {
   return (
     <Routes>
-      <Route path="/" element={<Home />} />
-      <Route path="/sobre-o-projeto" element={<SobreOProjeto />} />
-      <Route path="/catalogo" element={<Catalogo />} />
-      <Route path="/como-participar" element={<ComoParticipar />} />
-      <Route path="/contato" element={<Contato />} />
+      <Route element={<Layout />}>
+        <Route path="/" element={<Home />} />
+        <Route path="/sobre-o-projeto" element={<SobreOProjeto />} />
+        <Route path="/catalogo" element={<Catalogo />} />
+        <Route path="/como-participar" element={<ComoParticipar />} />
+        <Route path="/contato" element={<Contato />} />
+      </Route>
     </Routes>
   )
 }


### PR DESCRIPTION
## Summary
Traz para a `main` o trabalho da branch `feat/12-configurar-roteamento`, que já inclui:
- Roteamento com react-router-dom (#12, já mergeada em main via PR #49, sem alterações aqui)
- Layout base compartilhado, Header e Footer (#13, mergeada nesta branch via PR #50, mas não tinha chegado na main ainda)

Closes #13

## Test plan
- [x] `npm run lint` sem erros
- [x] `npm run build` sem erros