### PR TITLE
feat: migrar página Catálogo com filtro funcional em React

### DIFF
--- a/src/data/catalogItems.js
+++ b/src/data/catalogItems.js
@@ -1,0 +1,60 @@
+import itemImage1 from '../assets/item-image-1.jpg'
+import itemImage2 from '../assets/item-image-2.jpg'
+import itemImage3 from '../assets/item-image-3.jpg'
+
+export const categoryOptions = [
+  { value: '', label: 'Todas as categorias' },
+  { value: 'livros', label: 'Livros' },
+  { value: 'cadernos', label: 'Cadernos' },
+  { value: 'mochilas', label: 'Mochilas' },
+  { value: 'material-escrita', label: 'Material de escrita' },
+  { value: 'artes', label: 'Artes' },
+]
+
+export const conditionOptions = [
+  { value: '', label: 'Todos os estados' },
+  { value: 'novo', label: 'Novo' },
+  { value: 'seminovo', label: 'Seminovo' },
+  { value: 'usado', label: 'Usado' },
+]
+
+const catalogItems = [
+  {
+    id: 1,
+    image: itemImage1,
+    alt: 'Kit de Lápis de Cor 48 unidades',
+    category: 'artes',
+    categoryLabel: 'Artes',
+    condition: 'usado',
+    conditionLabel: 'Usado',
+    title: 'Kit de Lápis de Cor 48un.',
+    location: 'Fortaleza, CE',
+    donor: 'M. Oliveira',
+  },
+  {
+    id: 2,
+    image: itemImage2,
+    alt: 'Mochila Escolar Reforçada',
+    category: 'mochilas',
+    categoryLabel: 'Mochilas',
+    condition: 'seminovo',
+    conditionLabel: 'Seminovo',
+    title: 'Mochila Escolar Reforçada',
+    location: 'Caucaia, CE',
+    donor: 'R. Bezerra',
+  },
+  {
+    id: 3,
+    image: itemImage3,
+    alt: 'Coleção de Livros Didáticos',
+    category: 'livros',
+    categoryLabel: 'Livros',
+    condition: 'novo',
+    conditionLabel: 'Novo',
+    title: 'Coleção de Livros Didáticos',
+    location: 'Fortaleza, CE',
+    donor: 'S. Ferreira',
+  },
+]
+
+export default catalogItems

--- a/src/pages/Catalogo.jsx
+++ b/src/pages/Catalogo.jsx
@@ -1,8 +1,102 @@
+import { useMemo, useState } from 'react'
+import catalogItems, { categoryOptions, conditionOptions } from '../data/catalogItems.js'
+
 function Catalogo() {
+  const [category, setCategory] = useState('')
+  const [condition, setCondition] = useState('')
+  const [appliedFilters, setAppliedFilters] = useState({ category: '', condition: '' })
+
+  const filteredItems = useMemo(() => {
+    return catalogItems.filter((item) => {
+      const matchesCategory = !appliedFilters.category || item.category === appliedFilters.category
+      const matchesCondition = !appliedFilters.condition || item.condition === appliedFilters.condition
+      return matchesCategory && matchesCondition
+    })
+  }, [appliedFilters])
+
+  function handleSubmit(event) {
+    event.preventDefault()
+    setAppliedFilters({ category, condition })
+  }
+
   return (
-    <section>
-      <h1>Catálogo</h1>
-      <p>Página a implementar.</p>
+    <section id="catalog-section">
+      <h1 className="page-title">Catálogo de materiais</h1>
+      <div className="catalog-intro">
+        <p>
+          Explore os materiais escolares disponíveis para doação. Use os
+          filtros para encontrar o que você precisa por categoria ou estado
+          de conservação.
+        </p>
+
+        <form id="catalog-filters" onSubmit={handleSubmit}>
+          <div className="catalog-filters__field catalog-filters__field--category">
+            <label htmlFor="filter-category">Categoria</label>
+            <select
+              id="filter-category"
+              name="category"
+              value={category}
+              onChange={(event) => setCategory(event.target.value)}
+            >
+              {categoryOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="catalog-filters__field catalog-filters__field--condition">
+            <label htmlFor="filter-condition">Estado de conservação</label>
+            <select
+              id="filter-condition"
+              name="condition"
+              value={condition}
+              onChange={(event) => setCondition(event.target.value)}
+            >
+              {conditionOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <button type="submit" className="btn btn--primary">Filtrar</button>
+        </form>
+      </div>
+
+      <div className="catalog-grid">
+        {filteredItems.map((item) => (
+          <article key={item.id} className="catalog-card card-surface">
+            <figure className="catalog-card__figure">
+              <img className="catalog-card__image" src={item.image} alt={item.alt} />
+              <figcaption className="catalog-card__category">{item.categoryLabel}</figcaption>
+            </figure>
+
+            <div className="catalog-card__body">
+              <small className={`catalog-card__condition catalog-card__condition--${item.condition}`}>
+                {item.conditionLabel}
+              </small>
+
+              <h2 className="catalog-card__title">{item.title}</h2>
+
+              <ul className="catalog-card__meta">
+                <li>📍 {item.location}</li>
+                <li>👤 Doado por {item.donor}</li>
+              </ul>
+
+              <button type="button" className="btn btn--primary catalog-card__cta">Tenho Interesse</button>
+            </div>
+          </article>
+        ))}
+      </div>
+
+      {filteredItems.length === 0 && (
+        <p id="no-results" className="catalog-empty">
+          Nenhum item encontrado para os filtros selecionados.
+        </p>
+      )}
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- Migra o conteúdo de `paginas/catalogo.html` para `Catalogo.jsx`
- Modela os itens do catálogo como dados em `src/data/catalogItems.js`, ao invés de cards fixos no HTML
- Reescreve o filtro por categoria e estado de conservação (antes em jQuery, aplicado a `data-attributes` dos cards) usando `useState` para os selects e `useMemo` para a lista filtrada
- O filtro só é aplicado ao clicar em "Filtrar" (submit do formulário), replicando o comportamento original, não é live-filtering
- Exibe a mensagem de "nenhum resultado encontrado" quando o filtro não retorna itens
- Conecta a rota `/catalogo` (rota já existia desde a #12)

## Fora de escopo (propositalmente)
O dropdown customizado (`.select-custom`, com trigger/lista de opções estilizada) do site não foi replicado aqui, isso é escopo da #20, que depende deste PR. Por enquanto os filtros usam `<select>` nativo do HTML.

Closes #19

## Test plan
- [x] `npm run lint` sem erros
- [x] `npm run build` sem erros
- [ ] Conferência visual no navegador (não realizada nesta sessão, sem acesso a browser)