### PR TITLE
feat: reescrever dropdown customizado do filtro do catálogo em React

### DIFF
--- a/src/components/SelectCustom.jsx
+++ b/src/components/SelectCustom.jsx
@@ -1,0 +1,72 @@
+import { useEffect, useRef, useState } from 'react'
+
+function SelectCustom({ id, name, options, value, onChange }) {
+  const [open, setOpen] = useState(false)
+  const wrapperRef = useRef(null)
+
+  useEffect(() => {
+    function handleClickOutside(event) {
+      if (wrapperRef.current && !wrapperRef.current.contains(event.target)) {
+        setOpen(false)
+      }
+    }
+
+    document.addEventListener('click', handleClickOutside)
+    return () => document.removeEventListener('click', handleClickOutside)
+  }, [])
+
+  const selected = options.find((option) => option.value === value) ?? options[0]
+
+  function handleSelect(optionValue) {
+    onChange(optionValue)
+    setOpen(false)
+  }
+
+  return (
+    <div className="select-custom" ref={wrapperRef}>
+      <select
+        id={id}
+        name={name}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+      >
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+
+      <button
+        type="button"
+        className="select-custom__trigger"
+        onClick={(event) => {
+          event.stopPropagation()
+          setOpen((isOpen) => !isOpen)
+        }}
+      >
+        {selected.label}
+      </button>
+
+      <ul
+        className={
+          open
+            ? 'select-custom__options select-custom__options--open'
+            : 'select-custom__options'
+        }
+      >
+        {options.map((option) => (
+          <li
+            key={option.value}
+            data-value={option.value}
+            onClick={() => handleSelect(option.value)}
+          >
+            {option.label}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+export default SelectCustom

--- a/src/pages/Catalogo.jsx
+++ b/src/pages/Catalogo.jsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react'
 import catalogItems, { categoryOptions, conditionOptions } from '../data/catalogItems.js'
+import SelectCustom from '../components/SelectCustom.jsx'
 
 function Catalogo() {
   const [category, setCategory] = useState('')
@@ -32,34 +33,24 @@ function Catalogo() {
         <form id="catalog-filters" onSubmit={handleSubmit}>
           <div className="catalog-filters__field catalog-filters__field--category">
             <label htmlFor="filter-category">Categoria</label>
-            <select
+            <SelectCustom
               id="filter-category"
               name="category"
+              options={categoryOptions}
               value={category}
-              onChange={(event) => setCategory(event.target.value)}
-            >
-              {categoryOptions.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
+              onChange={setCategory}
+            />
           </div>
 
           <div className="catalog-filters__field catalog-filters__field--condition">
             <label htmlFor="filter-condition">Estado de conservação</label>
-            <select
+            <SelectCustom
               id="filter-condition"
               name="condition"
+              options={conditionOptions}
               value={condition}
-              onChange={(event) => setCondition(event.target.value)}
-            >
-              {conditionOptions.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
+              onChange={setCondition}
+            />
           </div>
 
           <button type="submit" className="btn btn--primary">Filtrar</button>


### PR DESCRIPTION
## Summary
- Cria `SelectCustom.jsx`, reescrevendo o menu de opções customizado (`.select-custom`) do site como componente controlado do React
- O `<select>` nativo fica escondido atrás do trigger customizado, mantendo a semântica de formulário
- Estado de aberto/fechado é local ao componente; um listener de clique fora fecha o dropdown, substituindo o listener global do jQuery
- Aplica o `SelectCustom` nos dois campos de filtro do `Catalogo.jsx` (categoria e estado de conservação), sincronizado com o mesmo estado já usado pelo filtro (da #19)

## Diferença de comportamento (não é regressão)
No jQuery original, abrir um dropdown fechava o outro automaticamente (só um aberto por vez). Como cada `SelectCustom` agora controla seu próprio estado, é possível ter os dois abertos ao mesmo tempo. Não achei que valia a complexidade de coordenar isso entre os dois campos para uma tela com só dois filtros, mas fica registrado caso vocês prefiram esse comportamento.

Closes #20

## Test plan
- [x] `npm run lint` sem erros
- [x] `npm run build` sem erros
- [ ] Conferência visual no navegador (não realizada nesta sessão, sem acesso a browser)