### PR TITLE
fix: ajustar texto das disciplinas na página Sobre o Projeto

### DIFF
--- a/src/pages/SobreOProjeto.jsx
+++ b/src/pages/SobreOProjeto.jsx
@@ -75,9 +75,9 @@ function SobreOProjeto() {
       <section id="team-section">
         <h2>Quem faz o Passa Adiante</h2>
         <p>
-          Somos a equipe Anteiku, do Polo Caucaia, desenvolvendo este projeto
-          na disciplina de Projeto Integrado 3 e Disciplina integrada{' '}
-          <em>Desenvolvimento para Web</em> da UFCA.
+          Somos a equipe Anteiku, do Polo Caucaia, e desenvolvemos este
+          projeto nas disciplinas de Projeto Integrado 3 e Desenvolvimento
+          para Web, da UFCA.
         </p>
 
         <ul className="team-section__list">


### PR DESCRIPTION
## Summary
Ajusta o texto da seção da equipe em `SobreOProjeto.jsx`:

- De: "Somos a equipe Anteiku, do Polo Caucaia, desenvolvendo este projeto na disciplina de Projeto Integrado 3 e Disciplina integrada *Desenvolvimento para Web* da UFCA."
- Para: "Somos a equipe Anteiku, do Polo Caucaia, e desenvolvemos este projeto nas disciplinas de Projeto Integrado 3 e Desenvolvimento para Web, da UFCA."

Remove o destaque em itálico (`<em>`) que estava em "Desenvolvimento para Web", agora sem nenhum destaque no texto.

## Test plan
- [x] `npm run lint` sem erros