### PR TITLE
feat: implementar menu mobile interativo no Header

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,7 +1,23 @@
+import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import logo from '../assets/logo.png'
+import menuIcon from '../assets/menu-icon.png'
+
+const NAV_LINKS = [
+  { to: '/', label: 'Início' },
+  { to: '/sobre-o-projeto', label: 'Sobre' },
+  { to: '/como-participar', label: 'Como participar' },
+  { to: '/catalogo', label: 'Catálogo' },
+  { to: '/contato', label: 'Contato' },
+]
 
 function Header() {
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
+
+  function closeMobileMenu() {
+    setMobileMenuOpen(false)
+  }
+
   return (
     <header className="header">
       <nav className="menu">
@@ -9,22 +25,58 @@ function Header() {
           <img src={logo} alt="PassaAdiante" />
         </Link>
 
+        <button
+          type="button"
+          className="menu__mobile"
+          aria-label="Abrir menu"
+          onClick={() => setMobileMenuOpen(true)}
+        >
+          <img src={menuIcon} alt="Ícone Menu Mobile" />
+        </button>
+
+        <div
+          className={
+            mobileMenuOpen ? 'menu__overlay menu__overlay--open' : 'menu__overlay'
+          }
+          onClick={closeMobileMenu}
+        />
+
+        <ul
+          className={
+            mobileMenuOpen
+              ? 'menu__list-mobile menu__list-mobile--open'
+              : 'menu__list-mobile'
+          }
+        >
+          <button
+            type="button"
+            className="menu__close"
+            aria-label="Fechar menu"
+            onClick={closeMobileMenu}
+          >
+            &times;
+          </button>
+
+          {NAV_LINKS.map((link) => (
+            <li className="menu__item" key={link.to}>
+              <Link to={link.to} className="menu__link" onClick={closeMobileMenu}>
+                {link.label}
+              </Link>
+            </li>
+          ))}
+
+          <div className="menu__mobile-actions">
+            <button type="button" className="btn btn--primary">Entrar</button>
+            <button type="button" className="btn btn--secondary">Cadastre-se</button>
+          </div>
+        </ul>
+
         <ul className="menu__list">
-          <li className="menu__item">
-            <Link to="/" className="menu__link">Início</Link>
-          </li>
-          <li className="menu__item">
-            <Link to="/sobre-o-projeto" className="menu__link">Sobre</Link>
-          </li>
-          <li className="menu__item">
-            <Link to="/como-participar" className="menu__link">Como participar</Link>
-          </li>
-          <li className="menu__item">
-            <Link to="/catalogo" className="menu__link">Catálogo</Link>
-          </li>
-          <li className="menu__item">
-            <Link to="/contato" className="menu__link">Contato</Link>
-          </li>
+          {NAV_LINKS.map((link) => (
+            <li className="menu__item" key={link.to}>
+              <Link to={link.to} className="menu__link">{link.label}</Link>
+            </li>
+          ))}
         </ul>
 
         <div className="menu__actions">


### PR DESCRIPTION
## Summary
- Reescreve o menu mobile (hambúrguer) como estado do React (`useState`), substituindo o toggle de classes via jQuery
- O botão hambúrguer, o botão de fechar e o clique no overlay controlam o mesmo estado `mobileMenuOpen`
- Extrai os 5 links de navegação para um array `NAV_LINKS`, reaproveitado na lista mobile e na lista desktop, evitando duplicar o JSX

## Adaptação necessária pra SPA
Ao clicar em um link dentro do menu mobile, o menu agora fecha automaticamente. No site estático original isso acontecia de graça porque cada link recarregava a página inteira; numa SPA em React isso não existe mais, então adicionei o fechamento explícito pra não deixar o menu mobile aberto ao navegar pra próxima página.

Closes #22

## Test plan
- [x] `npm run lint` sem erros
- [x] `npm run build` sem erros
- [x] Conferência visual no navegador (não realizada nesta sessão, sem acesso a browser)