### PR TITLE
feat: implementar página Dashboard com dados mockados

### DIFF
--- a/src/pages/app/Dashboard/Dashboard.jsx
+++ b/src/pages/app/Dashboard/Dashboard.jsx
@@ -1,0 +1,67 @@
+import styles from './Dashboard.module.css';
+
+const stats = [
+    { id: 1, value: 120, label: 'Total de Usuários', variant: styles.statCardDark },
+    { id: 2, value: 340, label: 'Total de Itens', variant: styles.statCardBlue },
+    { id: 3, value: 12, label: 'Pedidos Pendentes', variant: styles.statCardGreen },
+    { id: 4, value: 210, label: 'Itens Disponíveis', variant: styles.statCardCyan },
+];
+
+const ultimosPedidos = [
+    { id: '01', usuario: 'João', item: 'Livro', status: 'Pendente', data: '12/05/25' },
+    { id: '02', usuario: 'Maria', item: 'Mochila', status: 'Aprovado', data: '13/05/25' },
+    { id: '03', usuario: 'Clara', item: 'Estojo', status: 'Recusado', data: '11/05/25' },
+];
+
+export default function Dashboard() {
+    return (
+        <div className={styles.pageContainer}>
+            <div className={styles.statsRow}>
+                {stats.map((stat) => (
+                    <div className={`${styles.statCard} ${stat.variant}`} key={stat.id}>
+                        <span className={styles.statValue}>{stat.value}</span>
+                        <span className={styles.statLabel}>{stat.label}</span>
+                    </div>
+                ))}
+            </div>
+
+            <span className={styles.sectionTitle}>Últimos Pedidos</span>
+
+            <div className={styles.card}>
+                <div className={styles.tableWrapper}>
+                    <table className={styles.table}>
+                        <thead>
+                            <tr className={styles.tableHeader}>
+                                <th>ID</th>
+                                <th>Usuário</th>
+                                <th>Item</th>
+                                <th>Status</th>
+                                <th>Data</th>
+                                <th>Ação</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {ultimosPedidos.map((pedido) => (
+                                <tr className={styles.tableRow} key={pedido.id}>
+                                    <td>{pedido.id}</td>
+                                    <td>{pedido.usuario}</td>
+                                    <td>{pedido.item}</td>
+                                    <td>{pedido.status}</td>
+                                    <td>{pedido.data}</td>
+                                    <td>
+                                        <button className={styles.actionBtn} title="Visualizar">
+                                            <svg viewBox="0 0 24 24" width="18" height="18" stroke="currentColor" strokeWidth="2" fill="none">
+                                                <circle cx="11" cy="11" r="8" stroke="#374151" strokeWidth="1.5" />
+                                                <line x1="21" y1="21" x2="16.65" y2="16.65" stroke="#374151" strokeWidth="1.5" strokeLinecap="round" />
+                                            </svg>
+                                        </button>
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/pages/app/Dashboard/Dashboard.module.css
+++ b/src/pages/app/Dashboard/Dashboard.module.css
@@ -1,0 +1,124 @@
+.pageContainer {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    width: 100%;
+}
+
+.statsRow {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 24px;
+}
+
+.statCard {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 32px 16px;
+    border-radius: 16px;
+}
+
+.statValue {
+    font-size: 3rem;
+    font-weight: 700;
+}
+
+.statLabel {
+    font-size: 1.05rem;
+    font-weight: 500;
+    text-align: center;
+}
+
+.statCardDark {
+    background-color: #080640;
+    color: #d9d9d9;
+}
+
+.statCardBlue {
+    background-color: #36a0fd;
+    color: #080640;
+}
+
+.statCardGreen {
+    background-color: #078c5b;
+    color: #d9d9d9;
+}
+
+.statCardCyan {
+    background-color: #2bb9d9;
+    color: #080640;
+}
+
+.sectionTitle {
+    display: inline-flex;
+    align-items: center;
+    width: fit-content;
+    background-color: #79bed9;
+    color: #111827;
+    font-size: 1.25rem;
+    font-weight: 700;
+    padding: 12px 24px;
+    border-radius: 30px;
+}
+
+.card {
+    background-color: #ffffff;
+    border-radius: 12px;
+    border: 1px solid #e5e7eb;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+    overflow: hidden;
+}
+
+.tableWrapper {
+    overflow-x: auto;
+}
+
+.table {
+    width: 100%;
+    border-collapse: collapse;
+    text-align: left;
+}
+
+.tableHeader {
+    background-color: rgba(121, 199, 217, 0.8);
+    color: #111827;
+}
+
+.tableHeader th {
+    padding: 14px 20px;
+    font-weight: 700;
+    font-size: 0.95rem;
+}
+
+.tableRow:nth-child(odd) {
+    background-color: #f3f4f2;
+}
+
+.tableRow:nth-child(even) {
+    background-color: #dfe9e5;
+}
+
+.tableRow td {
+    padding: 16px 20px;
+    color: #374151;
+    font-size: 0.95rem;
+}
+
+.actionBtn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 4px;
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background-color 0.2s;
+}
+
+.actionBtn:hover {
+    background-color: rgba(0, 0, 0, 0.08);
+}

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -8,6 +8,7 @@ import Contato from './pages/Contato.jsx'
 
 import { AppLayout } from './layouts/AppLayout.jsx'
 import ListagemItems from './pages/app/ListagemItems/ListagemItems.jsx'
+import Dashboard from './pages/app/Dashboard/Dashboard.jsx'
 
 function AppRoutes() {
   return (
@@ -21,7 +22,7 @@ function AppRoutes() {
       </Route>
 
       <Route path="/app" element={<AppLayout />}>
-        <Route path="dashboard" element={<h1>Dashboard</h1>} />
+        <Route path="dashboard" element={<Dashboard />} />
         <Route path="items" element={<ListagemItems />} />
         <Route path="pedidos" element={<h1>Solicitações</h1>} />
         <Route path="usuarios" element={<h1>Usuários</h1>} />


### PR DESCRIPTION
## Summary
Implementa `Dashboard.jsx` conforme o frame "Dashboard" do Figma (consultado via `get_design_context`), seguindo o padrão já estabelecido pelo colega em `ListagemItems` (pasta por página, CSS Modules, dados mockados locais, SVG inline pros ícones).

- 4 cards de resumo (Total de Usuários, Total de Itens, Pedidos Pendentes, Itens Disponíveis), com as cores exatas do Figma
- Tabela "Últimos Pedidos" com 3 pedidos mockados (ID, Usuário, Item, Status, Data, Ação), zebra striping via CSS `nth-child` ao invés de replicar linhas vazias fixas do mockup
- Ícone de "Ação" como lupa em SVG inline, no mesmo estilo do ícone de busca já usado em `ListagemItems`
- Conecta a rota `/app/dashboard`, substituindo o placeholder `<h1>Dashboard</h1>`

<img width="1878" height="948" alt="image" src="https://github.com/user-attachments/assets/4c0e1766-5a45-4fda-baee-ea98fb87321a" />


## Decisões que fogem do 1:1 com o Figma
- Não trouxe as imagens de fundo decorativas (blobs) do frame, para manter consistência com o cartão branco liso já usado em `ListagemItems`/`AppLayout`
- Não apliquei a fonte Roboto especificada só nesse frame; o resto da área logada já herda Inter do reset global
- Layout convertido de posicionamento absoluto (canvas fixo do Figma) para flex/grid responsivo, mesma abordagem já usada em `ListagemItems`

Closes #34

## Test plan
- [x] `npm run lint` sem erros
- [x] `npm run build` sem erros
- [ ] Conferência visual no navegador (não realizada nesta sessão, sem acesso a browser)