### PR TITLE
feat: implementar página de criar/editar item com dados mockados

### DIFF
--- a/src/data/mockItems.js
+++ b/src/data/mockItems.js
@@ -1,0 +1,19 @@
+export const categoriaOptions = ['Livro', 'Acessório', 'Eletrônico', 'Papelaria'];
+export const estadoOptions = ['Novo', 'Usado'];
+export const disponivelOptions = ['Sim', 'Não'];
+
+const mockItems = [
+    { id: 1, nome: 'Livro de Ciências', categoria: 'Livro', estado: 'Usado', disponivel: 'Sim' },
+    { id: 2, nome: 'Mochila c/ roda', categoria: 'Acessório', estado: 'Usado', disponivel: 'Não' },
+    { id: 3, nome: 'Caderno 10 Mat.', categoria: 'Livro', estado: 'Novo', disponivel: 'Sim' },
+    { id: 4, nome: 'Kit de canetas', categoria: 'Acessório', estado: 'Novo', disponivel: 'Não' },
+    { id: 5, nome: 'Canetinhas', categoria: 'Acessório', estado: 'Novo', disponivel: 'Sim' },
+    { id: 6, nome: 'Dicionário de Inglês', categoria: 'Livro', estado: 'Novo', disponivel: 'Sim' },
+    { id: 7, nome: 'Estojo escolar', categoria: 'Acessório', estado: 'Usado', disponivel: 'Sim' },
+    { id: 8, nome: 'Calculadora Científica', categoria: 'Eletrônico', estado: 'Novo', disponivel: 'Não' },
+    { id: 9, nome: 'Bloco de Notas', categoria: 'Papelaria', estado: 'Novo', disponivel: 'Sim' },
+    { id: 10, nome: 'Regua 30cm', categoria: 'Papelaria', estado: 'Usado', disponivel: 'Sim' },
+    { id: 11, nome: 'Tesoura escolar', categoria: 'Papelaria', estado: 'Novo', disponivel: 'Não' }
+];
+
+export default mockItems;

--- a/src/pages/app/ListagemItems/ListagemItems.jsx
+++ b/src/pages/app/ListagemItems/ListagemItems.jsx
@@ -1,23 +1,12 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import styles from './ListagemItems.module.css';
-
-const mockItems = [
-    { id: 1, nome: 'Livro de Ciências', categoria: 'Livro', estado: 'Usado', disponivel: 'Sim' },
-    { id: 2, nome: 'Mochila c/ roda', categoria: 'Acessório', estado: 'Usado', disponivel: 'Não' },
-    { id: 3, nome: 'Caderno 10 Mat.', categoria: 'Livro', estado: 'Novo', disponivel: 'Sim' },
-    { id: 4, nome: 'Kit de canetas', categoria: 'Acessório', estado: 'Novo', disponivel: 'Não' },
-    { id: 5, nome: 'Canetinhas', categoria: 'Acessório', estado: 'Novo', disponivel: 'Sim' },
-    { id: 6, nome: 'Dicionário de Inglês', categoria: 'Livro', estado: 'Novo', disponivel: 'Sim' },
-    { id: 7, nome: 'Estojo escolar', categoria: 'Acessório', estado: 'Usado', disponivel: 'Sim' },
-    { id: 8, nome: 'Calculadora Científica', categoria: 'Eletrônico', estado: 'Novo', disponivel: 'Não' },
-    { id: 9, nome: 'Bloco de Notas', categoria: 'Papelaria', estado: 'Novo', disponivel: 'Sim' },
-    { id: 10, nome: 'Regua 30cm', categoria: 'Papelaria', estado: 'Usado', disponivel: 'Sim' },
-    { id: 11, nome: 'Tesoura escolar', categoria: 'Papelaria', estado: 'Novo', disponivel: 'Não' }
-];
+import mockItems from '../../../data/mockItems.js';
 
 const ITEMS_PER_PAGE = 5;
 
 export default function ListagemItems() {
+    const navigate = useNavigate();
     const [searchTerm, setSearchTerm] = useState('');
     const [currentPage, setCurrentPage] = useState(1);
 
@@ -47,7 +36,7 @@ export default function ListagemItems() {
         <div className={styles.pageContainer}>
             <div className={styles.headerRow}>
                 <h2 className={styles.pageTitle}>Listagem de Itens</h2>
-                <button className={styles.addButton}>
+                <button className={styles.addButton} onClick={() => navigate('/app/items/novo')}>
                     Adicionar item
                 </button>
             </div>
@@ -97,7 +86,11 @@ export default function ListagemItems() {
                                         <td>{item.estado}</td>
                                         <td>{item.disponivel}</td>
                                         <td>
-                                            <button className={styles.actionBtn} title="Visualizar">
+                                            <button
+                                                className={styles.actionBtn}
+                                                title="Visualizar"
+                                                onClick={() => navigate(`/app/items/${item.id}`)}
+                                            >
                                                 <svg viewBox="0 0 24 24" width="18" height="18" stroke="currentColor" strokeWidth="2" fill="none">
                                                     <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" stroke="#374151" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
                                                     <circle cx="12" cy="12" r="3" stroke="#374151" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />

--- a/src/pages/app/PaginaItem/PaginaItem.jsx
+++ b/src/pages/app/PaginaItem/PaginaItem.jsx
@@ -1,0 +1,94 @@
+import { useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import styles from './PaginaItem.module.css';
+import mockItems, { categoriaOptions, estadoOptions, disponivelOptions } from '../../../data/mockItems.js';
+
+const emptyItem = { nome: '', categoria: categoriaOptions[0], estado: estadoOptions[0], disponivel: disponivelOptions[0] };
+
+export default function PaginaItem() {
+    const navigate = useNavigate();
+    const { id } = useParams();
+    const isEditing = id !== undefined && id !== 'novo';
+    const existingItem = isEditing ? mockItems.find((item) => String(item.id) === id) : null;
+
+    const [form, setForm] = useState(existingItem ?? emptyItem);
+
+    function handleChange(field, value) {
+        setForm((current) => ({ ...current, [field]: value }));
+    }
+
+    function handleSubmit(event) {
+        event.preventDefault();
+        // Dados mockados: sem persistência real ainda, isso é escopo da integração com a API (#43).
+        navigate('/app/items');
+    }
+
+    return (
+        <div className={styles.pageContainer}>
+            <h2 className={styles.pageTitle}>
+                {isEditing ? `Editar item: ${existingItem?.nome ?? ''}` : 'Adicionar item'}
+            </h2>
+
+            <form className={styles.card} onSubmit={handleSubmit}>
+                <div className={styles.field}>
+                    <label htmlFor="item-nome">Nome do item:</label>
+                    <input
+                        id="item-nome"
+                        type="text"
+                        value={form.nome}
+                        onChange={(event) => handleChange('nome', event.target.value)}
+                        required
+                    />
+                </div>
+
+                <div className={styles.field}>
+                    <label htmlFor="item-categoria">Categoria:</label>
+                    <select
+                        id="item-categoria"
+                        value={form.categoria}
+                        onChange={(event) => handleChange('categoria', event.target.value)}
+                    >
+                        {categoriaOptions.map((option) => (
+                            <option key={option} value={option}>{option}</option>
+                        ))}
+                    </select>
+                </div>
+
+                <div className={styles.field}>
+                    <label htmlFor="item-estado">Estado de conservação:</label>
+                    <select
+                        id="item-estado"
+                        value={form.estado}
+                        onChange={(event) => handleChange('estado', event.target.value)}
+                    >
+                        {estadoOptions.map((option) => (
+                            <option key={option} value={option}>{option}</option>
+                        ))}
+                    </select>
+                </div>
+
+                <div className={styles.field}>
+                    <label htmlFor="item-disponivel">Disponível:</label>
+                    <select
+                        id="item-disponivel"
+                        value={form.disponivel}
+                        onChange={(event) => handleChange('disponivel', event.target.value)}
+                    >
+                        {disponivelOptions.map((option) => (
+                            <option key={option} value={option}>{option}</option>
+                        ))}
+                    </select>
+                </div>
+
+                <div className={styles.actions}>
+                    <button type="button" className={styles.cancelButton} onClick={() => navigate('/app/items')}>
+                        Cancelar
+                    </button>
+                    <button type="submit" className={styles.saveButton}>
+                        {isEditing ? 'Salvar alterações' : 'Adicionar item'}
+                    </button>
+                </div>
+            </form>
+        </div>
+    );
+}

--- a/src/pages/app/PaginaItem/PaginaItem.module.css
+++ b/src/pages/app/PaginaItem/PaginaItem.module.css
@@ -1,0 +1,90 @@
+.pageContainer {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    width: 100%;
+    max-width: 640px;
+}
+
+.pageTitle {
+    font-size: 1.5rem;
+    font-weight: bold;
+    color: #111827;
+    margin: 0;
+}
+
+.card {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    background-color: #ffffff;
+    border-radius: 12px;
+    border: 1px solid #e5e7eb;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+    padding: 24px;
+}
+
+.field {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.field label {
+    font-weight: 700;
+    font-size: 1rem;
+    color: #111827;
+}
+
+.field input,
+.field select {
+    height: 48px;
+    padding: 0 16px;
+    border: 1px solid #ccd5dc;
+    border-radius: 10px;
+    font-size: 1rem;
+    background-color: #ffffff;
+    color: #111827;
+}
+
+.field input:focus,
+.field select:focus {
+    outline: none;
+    border-color: #0d6efd;
+}
+
+.actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+    margin-top: 8px;
+}
+
+.cancelButton {
+    background: none;
+    border: 1px solid #ccd5dc;
+    color: #374151;
+    padding: 10px 20px;
+    border-radius: 8px;
+    font-weight: 500;
+    cursor: pointer;
+}
+
+.cancelButton:hover {
+    background-color: #f3f4f6;
+}
+
+.saveButton {
+    background-color: #0d6efd;
+    color: #ffffff;
+    border: none;
+    padding: 10px 20px;
+    border-radius: 8px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.saveButton:hover {
+    background-color: #0b5ed7;
+}

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -9,6 +9,7 @@ import Contato from './pages/Contato.jsx'
 import { AppLayout } from './layouts/AppLayout.jsx'
 import ListagemItems from './pages/app/ListagemItems/ListagemItems.jsx'
 import ListagemUsuarios from './pages/app/ListagemUsuarios/ListagemUsuarios.jsx'
+import PaginaItem from './pages/app/PaginaItem/PaginaItem.jsx'
 
 function AppRoutes() {
   return (
@@ -24,6 +25,8 @@ function AppRoutes() {
       <Route path="/app" element={<AppLayout />}>
         <Route path="dashboard" element={<h1>Dashboard</h1>} />
         <Route path="items" element={<ListagemItems />} />
+        <Route path="items/novo" element={<PaginaItem />} />
+        <Route path="items/:id" element={<PaginaItem />} />
         <Route path="pedidos" element={<h1>Solicitações</h1>} />
         <Route path="usuarios" element={<ListagemUsuarios />} />
       </Route>


### PR DESCRIPTION
## Summary
O frame "Página de Items" do Figma está vazio (só o header, sem formulário desenhado). Montei o formulário seguindo a linguagem visual do frame "Página de Pedido" (inputs brancos com borda `#ccd5dc`, radius 10px, label em negrito acima do campo), a referência mais próxima de tela de formulário existente no protótipo.

- `PaginaItem.jsx` atende tanto criação (`/app/items/novo`) quanto edição (`/app/items/:id`) no mesmo componente, alternando pelo parâmetro de rota
- Campos: nome (input), categoria/estado/disponível (select), usando as mesmas opções já usadas na listagem
- Extrai o array `mockItems` de `ListagemItems.jsx` para `src/data/mockItems.js`, compartilhado entre a listagem e o formulário (a edição precisa achar o item pelo id)
- Conecta o botão "Adicionar item" e o botão de visualizar de cada linha da listagem pra navegar até a página de item (antes eram botões inertes)

## Fora de escopo (propositalmente)
Sem persistência real ainda, o submit só navega de volta pra listagem. Isso é escopo da integração com a API (#43).

Closes #36

## Test plan
- [x] `npm run lint` sem erros
- [x] `npm run build` sem erros
- [ ] Conferência visual no navegador (não realizada nesta sessão, sem acesso a browser)