### PR TITLE
feat: implementar página Listagem de Pedidos com dados mockados

### DIFF
--- a/src/data/mockPedidos.js
+++ b/src/data/mockPedidos.js
@@ -1,0 +1,13 @@
+export const statusOptions = ['Pendente', 'Aprovado', 'Recusado', 'Concluído'];
+
+const mockPedidos = [
+    { id: '01', usuario: 'João', item: 'Livro', status: 'Pendente', data: '12/05/25' },
+    { id: '02', usuario: 'Maria', item: 'Mochila', status: 'Aprovado', data: '13/05/25' },
+    { id: '03', usuario: 'Clara', item: 'Estojo', status: 'Recusado', data: '11/05/25' },
+    { id: '04', usuario: 'Pedro', item: 'Calculadora Científica', status: 'Pendente', data: '14/05/25' },
+    { id: '05', usuario: 'Ana', item: 'Dicionário de Inglês', status: 'Concluído', data: '10/05/25' },
+    { id: '06', usuario: 'Lucas', item: 'Kit de canetas', status: 'Aprovado', data: '15/05/25' },
+    { id: '07', usuario: 'Beatriz', item: 'Bloco de Notas', status: 'Pendente', data: '15/05/25' },
+];
+
+export default mockPedidos;

--- a/src/pages/app/ListagemPedidos/ListagemPedidos.jsx
+++ b/src/pages/app/ListagemPedidos/ListagemPedidos.jsx
@@ -1,0 +1,143 @@
+import { useState } from 'react';
+import styles from './ListagemPedidos.module.css';
+import mockPedidos from '../../../data/mockPedidos.js';
+
+const PEDIDOS_PER_PAGE = 5;
+
+export default function ListagemPedidos() {
+    const [searchTerm, setSearchTerm] = useState('');
+    const [currentPage, setCurrentPage] = useState(1);
+
+    const filteredPedidos = mockPedidos.filter(pedido =>
+        pedido.usuario.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        pedido.item.toLowerCase().includes(searchTerm.toLowerCase())
+    );
+
+    const totalPages = Math.ceil(filteredPedidos.length / PEDIDOS_PER_PAGE) || 1;
+    const validCurrentPage = Math.min(currentPage, totalPages);
+
+    const startIndex = (validCurrentPage - 1) * PEDIDOS_PER_PAGE;
+    const currentPedidos = filteredPedidos.slice(startIndex, startIndex + PEDIDOS_PER_PAGE);
+
+    const handleSearchChange = (e) => {
+        setSearchTerm(e.target.value);
+        setCurrentPage(1);
+    };
+
+    const handlePageChange = (pageNumber) => {
+        if (pageNumber >= 1 && pageNumber <= totalPages) {
+            setCurrentPage(pageNumber);
+        }
+    };
+
+    return (
+        <div className={styles.pageContainer}>
+            <div className={styles.headerRow}>
+                <h2 className={styles.pageTitle}>Listagem de Pedidos</h2>
+            </div>
+
+            <div className={styles.filterRow}>
+                <div className={styles.searchContainer}>
+                    <svg className={styles.searchIcon} viewBox="0 0 24 24" width="18" height="18" stroke="currentColor" strokeWidth="2" fill="none">
+                        <circle cx="11" cy="11" r="8" stroke="#9CA3AF" strokeWidth="1.5" />
+                        <line x1="21" y1="21" x2="16.65" y2="16.65" stroke="#9CA3AF" strokeWidth="1.5" strokeLinecap="round" />
+                    </svg>
+                    <input
+                        type="text"
+                        placeholder="Buscar por usuário ou item"
+                        value={searchTerm}
+                        onChange={handleSearchChange}
+                        className={styles.searchInput}
+                    />
+                </div>
+            </div>
+
+            <div className={styles.card}>
+                <div className={styles.tableWrapper}>
+                    <table className={styles.table}>
+                        <thead>
+                            <tr className={styles.tableHeader}>
+                                <th>
+                                    ID <span className={styles.sortIcon}>↕</span>
+                                </th>
+                                <th>
+                                    Usuário <span className={styles.sortIcon}>↕</span>
+                                </th>
+                                <th>
+                                    Item <span className={styles.sortIcon}>↕</span>
+                                </th>
+                                <th>
+                                    Status <span className={styles.sortIcon}>↕</span>
+                                </th>
+                                <th>
+                                    Data <span className={styles.sortIcon}>↕</span>
+                                </th>
+                                <th>Ação</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {currentPedidos.length > 0 ? (
+                                currentPedidos.map((pedido) => (
+                                    <tr key={pedido.id} className={styles.tableRow}>
+                                        <td>{pedido.id}</td>
+                                        <td>{pedido.usuario}</td>
+                                        <td>{pedido.item}</td>
+                                        <td>{pedido.status}</td>
+                                        <td>{pedido.data}</td>
+                                        <td>
+                                            <button className={styles.actionBtn} title="Visualizar">
+                                                <svg viewBox="0 0 24 24" width="18" height="18" stroke="currentColor" strokeWidth="2" fill="none">
+                                                    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" stroke="#374151" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                                                    <circle cx="12" cy="12" r="3" stroke="#374151" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                                                </svg>
+                                            </button>
+                                        </td>
+                                    </tr>
+                                ))
+                            ) : (
+                                <tr>
+                                    <td colSpan="6" style={{ textAlign: 'center', padding: '24px', color: '#6b7280' }}>
+                                        Nenhum pedido encontrado.
+                                    </td>
+                                </tr>
+                            )}
+                        </tbody>
+                    </table>
+                </div>
+
+                {totalPages > 1 && (
+                    <div className={styles.pagination}>
+                        <button
+                            className={styles.pageArrow}
+                            onClick={() => handlePageChange(validCurrentPage - 1)}
+                            disabled={validCurrentPage === 1}
+                        >
+                            &lt;
+                        </button>
+
+                        {Array.from({ length: totalPages }, (_, index) => {
+                            const pageNum = index + 1;
+                            return (
+                                <button
+                                    key={pageNum}
+                                    className={`${styles.pageNumber} ${validCurrentPage === pageNum ? styles.active : ''}`}
+                                    onClick={() => handlePageChange(pageNum)}
+                                >
+                                    {pageNum}
+                                </button>
+                            );
+                        })}
+
+                        <button
+                            className={styles.pageArrow}
+                            onClick={() => handlePageChange(validCurrentPage + 1)}
+                            disabled={validCurrentPage === totalPages}
+                        >
+                            &gt;
+                        </button>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/src/pages/app/ListagemPedidos/ListagemPedidos.module.css
+++ b/src/pages/app/ListagemPedidos/ListagemPedidos.module.css
@@ -1,0 +1,158 @@
+.pageContainer {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    width: 100%;
+}
+
+.headerRow {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.pageTitle {
+    font-size: 1.5rem;
+    font-weight: bold;
+    color: #111827;
+    margin: 0;
+}
+
+.filterRow {
+    display: flex;
+    align-items: center;
+}
+
+.searchContainer {
+    position: relative;
+    width: 320px;
+}
+
+.searchIcon {
+    position: absolute;
+    left: 14px;
+    top: 50%;
+    transform: translateY(-50%);
+}
+
+.searchInput {
+    width: 100%;
+    padding: 10px 14px 10px 42px;
+    border: 1px solid #d1d5db;
+    border-radius: 8px;
+    background-color: #f9fafb;
+    font-size: 0.95rem;
+    outline: none;
+    transition: border-color 0.2s;
+}
+
+.searchInput:focus {
+    border-color: #1a6396;
+    background-color: #ffffff;
+}
+
+.card {
+    background-color: #ffffff;
+    border-radius: 12px;
+    border: 1px solid #e5e7eb;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+    overflow: hidden;
+    padding: 24px;
+}
+
+.tableWrapper {
+    overflow-x: auto;
+}
+
+.table {
+    width: 100%;
+    border-collapse: collapse;
+    text-align: left;
+}
+
+.tableHeader {
+    background-color: #1a6396;
+    color: #ffffff;
+}
+
+.tableHeader th {
+    padding: 14px 20px;
+    font-weight: 600;
+    font-size: 0.95rem;
+}
+
+.sortIcon {
+    font-size: 0.8rem;
+    margin-left: 4px;
+    opacity: 0.8;
+}
+
+.tableRow {
+    border-bottom: 1px solid #e5e7eb;
+    transition: background-color 0.15s;
+}
+
+.tableRow:last-child {
+    border-bottom: none;
+}
+
+.tableRow:hover {
+    background-color: #f9fafb;
+}
+
+.tableRow td {
+    padding: 16px 20px;
+    color: #374151;
+    font-size: 0.95rem;
+}
+
+.actionBtn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 4px;
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background-color 0.2s;
+}
+
+.actionBtn:hover {
+    background-color: #f3f4f6;
+}
+
+.pagination {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 8px;
+    margin-top: 24px;
+}
+
+.pageNumber,
+.pageArrow {
+    background: none;
+    border: none;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    font-size: 0.9rem;
+    color: #4b5563;
+    transition: background-color 0.2s, color 0.2s;
+}
+
+.pageNumber:hover,
+.pageArrow:hover {
+    background-color: #f3f4f6;
+}
+
+.pageNumber.active {
+    background-color: #1a6396;
+    color: #ffffff;
+    font-weight: 600;
+}

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -11,6 +11,7 @@ import ListagemItems from './pages/app/ListagemItems/ListagemItems.jsx'
 import ListagemUsuarios from './pages/app/ListagemUsuarios/ListagemUsuarios.jsx'
 import Dashboard from './pages/app/Dashboard/Dashboard.jsx'
 import PaginaItem from './pages/app/PaginaItem/PaginaItem.jsx'
+import ListagemPedidos from './pages/app/ListagemPedidos/ListagemPedidos.jsx'
 
 function AppRoutes() {
   return (
@@ -28,7 +29,7 @@ function AppRoutes() {
         <Route path="items" element={<ListagemItems />} />
         <Route path="items/novo" element={<PaginaItem />} />
         <Route path="items/:id" element={<PaginaItem />} />
-        <Route path="pedidos" element={<h1>Solicitações</h1>} />
+        <Route path="pedidos" element={<ListagemPedidos />} />
         <Route path="usuarios" element={<ListagemUsuarios />} />
       </Route>
     </Routes>


### PR DESCRIPTION
## Summary
O frame "Listagem de Pedidos" do Figma está vazio (só o header, sem tabela desenhada). Implementei `ListagemPedidos.jsx` seguindo o mesmo padrão das outras listagens já implementadas (`ListagemItems`, `ListagemUsuarios`): busca, tabela, paginação, mesmo CSS Module.

- Colunas da tabela (ID, Usuário, Item, Status, Data, Ação) reaproveitam as mesmas do quadro "Últimos Pedidos" do Dashboard (#34), a única referência real de dados de pedido no Figma
- Dados mockados em `src/data/mockPedidos.js`, compartilhado para as issues futuras de detalhe do pedido (#38, #39) poderem localizar um pedido pelo id
- Botão de "Ação" fica inerte por enquanto (sem destino ainda), seguindo o mesmo padrão usado em `ListagemUsuarios`: só é conectado quando a tela de detalhe correspondente existir
- Conecta a rota `/app/pedidos`, substituindo o placeholder `<h1>Solicitações</h1>`

Closes #37

## Test plan
- [x] `npm run lint` sem erros
- [x] `npm run build` sem erros
- [x] Conferência visual no navegador (não realizada nesta sessão, sem acesso a browser)