### PR TITLE
feat: implementar tela de Pedido Aguardando Aprovação com dados mockados

### DIFF
--- a/src/data/mockPedidos.js
+++ b/src/data/mockPedidos.js
@@ -1,13 +1,13 @@
 export const statusOptions = ['Pendente', 'Aprovado', 'Recusado', 'Concluído'];
 
 const mockPedidos = [
-    { id: '01', usuario: 'João', item: 'Livro', status: 'Pendente', data: '12/05/25' },
-    { id: '02', usuario: 'Maria', item: 'Mochila', status: 'Aprovado', data: '13/05/25' },
-    { id: '03', usuario: 'Clara', item: 'Estojo', status: 'Recusado', data: '11/05/25' },
-    { id: '04', usuario: 'Pedro', item: 'Calculadora Científica', status: 'Pendente', data: '14/05/25' },
-    { id: '05', usuario: 'Ana', item: 'Dicionário de Inglês', status: 'Concluído', data: '10/05/25' },
-    { id: '06', usuario: 'Lucas', item: 'Kit de canetas', status: 'Aprovado', data: '15/05/25' },
-    { id: '07', usuario: 'Beatriz', item: 'Bloco de Notas', status: 'Pendente', data: '15/05/25' },
+    { id: '01', usuario: 'João Pedro Lima', email: 'joao.lima@email.com', item: 'Livro', status: 'Pendente', data: '12/05/25' },
+    { id: '02', usuario: 'Maria Souza', email: 'maria.souza@email.com', item: 'Mochila', status: 'Aprovado', data: '13/05/25' },
+    { id: '03', usuario: 'Clara Nunes', email: 'clara.nunes@email.com', item: 'Estojo', status: 'Recusado', data: '11/05/25' },
+    { id: '04', usuario: 'Pedro Alves', email: 'pedro.alves@email.com', item: 'Calculadora Científica', status: 'Pendente', data: '14/05/25' },
+    { id: '05', usuario: 'Ana Beatriz', email: 'ana.beatriz@email.com', item: 'Dicionário de Inglês', status: 'Concluído', data: '10/05/25' },
+    { id: '06', usuario: 'Lucas Martins', email: 'lucas.martins@email.com', item: 'Kit de canetas', status: 'Aprovado', data: '15/05/25' },
+    { id: '07', usuario: 'Beatriz Rocha', email: 'beatriz.rocha@email.com', item: 'Bloco de Notas', status: 'Pendente', data: '15/05/25' },
 ];
 
 export default mockPedidos;

--- a/src/pages/app/ListagemPedidos/ListagemPedidos.jsx
+++ b/src/pages/app/ListagemPedidos/ListagemPedidos.jsx
@@ -1,10 +1,12 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import styles from './ListagemPedidos.module.css';
 import mockPedidos from '../../../data/mockPedidos.js';
 
 const PEDIDOS_PER_PAGE = 5;
 
 export default function ListagemPedidos() {
+    const navigate = useNavigate();
     const [searchTerm, setSearchTerm] = useState('');
     const [currentPage, setCurrentPage] = useState(1);
 
@@ -85,7 +87,11 @@ export default function ListagemPedidos() {
                                         <td>{pedido.status}</td>
                                         <td>{pedido.data}</td>
                                         <td>
-                                            <button className={styles.actionBtn} title="Visualizar">
+                                            <button
+                                                className={styles.actionBtn}
+                                                title="Visualizar"
+                                                onClick={() => navigate(`/app/pedidos/${pedido.id}`)}
+                                            >
                                                 <svg viewBox="0 0 24 24" width="18" height="18" stroke="currentColor" strokeWidth="2" fill="none">
                                                     <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" stroke="#374151" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
                                                     <circle cx="12" cy="12" r="3" stroke="#374151" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />

--- a/src/pages/app/PedidoAguardandoAprovacao/PedidoAguardandoAprovacao.jsx
+++ b/src/pages/app/PedidoAguardandoAprovacao/PedidoAguardandoAprovacao.jsx
@@ -1,0 +1,88 @@
+import { useNavigate, useParams } from 'react-router-dom';
+import styles from './PedidoAguardandoAprovacao.module.css';
+import mockPedidos from '../../../data/mockPedidos.js';
+
+export default function PedidoAguardandoAprovacao() {
+    const navigate = useNavigate();
+    const { id } = useParams();
+    const pedido = mockPedidos.find((item) => item.id === id);
+
+    function handleAprovar() {
+        // Sem persistência real ainda, isso é escopo da integração com a API (#44).
+        navigate('/app/pedidos');
+    }
+
+    function handleCancelar() {
+        navigate('/app/pedidos');
+    }
+
+    if (!pedido) {
+        return (
+            <div className={styles.pageContainer}>
+                <p>Pedido não encontrado.</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className={styles.pageContainer}>
+            <h2 className={styles.pageTitle}>Pedido: #{pedido.id}</h2>
+
+            <div className={styles.content}>
+                <div className={styles.mediaColumn}>
+                    <div className={styles.imagePlaceholder}>
+                        <svg viewBox="0 0 24 24" width="48" height="48" stroke="currentColor" strokeWidth="1.5" fill="none">
+                            <rect x="3" y="3" width="18" height="18" rx="2" stroke="#6b7280" />
+                            <circle cx="8.5" cy="8.5" r="1.5" stroke="#6b7280" />
+                            <path d="M21 15l-5-5L5 21" stroke="#6b7280" />
+                        </svg>
+                    </div>
+                    <p className={styles.solicitanteInfo}>
+                        Solicitante: {pedido.usuario}<br />
+                        Email: {pedido.email}
+                    </p>
+                </div>
+
+                <div className={styles.formColumn}>
+                    <div className={styles.field}>
+                        <span className={styles.fieldLabel}>Item Solicitado:</span>
+                        <div className={styles.fieldBox}>{pedido.item}</div>
+                    </div>
+
+                    <div className={styles.field}>
+                        <span className={styles.fieldLabel}>Status:</span>
+                        <div className={styles.fieldBox}>{pedido.status}</div>
+                    </div>
+
+                    <div className={styles.field}>
+                        <span className={styles.fieldLabel}>Data:</span>
+                        <div className={`${styles.fieldBox} ${styles.fieldBoxDisabled}`}>{pedido.data}</div>
+                    </div>
+                </div>
+            </div>
+
+            <div className={styles.actions}>
+                <button type="button" className={styles.approveButton} onClick={handleAprovar}>
+                    <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" strokeWidth="2" fill="none">
+                        <path d="M5 13l4 4L19 7" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                    Aprovar
+                </button>
+                <button type="button" className={styles.cancelButton} onClick={handleCancelar}>
+                    <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" strokeWidth="2" fill="none">
+                        <circle cx="12" cy="12" r="9" />
+                        <path d="M9 9l6 6M15 9l-6 6" strokeLinecap="round" />
+                    </svg>
+                    Cancelar
+                </button>
+                <button type="button" className={styles.completeButton} disabled>
+                    <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" strokeWidth="2" fill="none">
+                        <path d="M2 13l4 4L14 9" strokeLinecap="round" strokeLinejoin="round" />
+                        <path d="M10 13l4 4L22 9" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                    Concluir
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/src/pages/app/PedidoAguardandoAprovacao/PedidoAguardandoAprovacao.module.css
+++ b/src/pages/app/PedidoAguardandoAprovacao/PedidoAguardandoAprovacao.module.css
@@ -1,0 +1,126 @@
+.pageContainer {
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+    width: 100%;
+}
+
+.pageTitle {
+    font-size: 1.75rem;
+    font-weight: bold;
+    color: #111827;
+    margin: 0;
+}
+
+.content {
+    display: flex;
+    gap: 48px;
+    align-items: flex-start;
+    flex-wrap: wrap;
+}
+
+.mediaColumn {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    flex: 1;
+    min-width: 280px;
+    max-width: 420px;
+}
+
+.imagePlaceholder {
+    width: 100%;
+    aspect-ratio: 5 / 4;
+    background-color: #d9d9d9;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 8px;
+}
+
+.solicitanteInfo {
+    font-size: 1.1rem;
+    color: #111827;
+    line-height: 1.8;
+    margin: 0;
+}
+
+.formColumn {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    flex: 1;
+    min-width: 280px;
+    max-width: 420px;
+}
+
+.field {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.fieldLabel {
+    font-weight: 700;
+    font-size: 1.1rem;
+    color: #111827;
+}
+
+.fieldBox {
+    background-color: #ffffff;
+    border: 1px solid #ccd5dc;
+    border-radius: 10px;
+    padding: 16px 20px;
+    font-size: 1rem;
+    color: #111827;
+}
+
+.fieldBoxDisabled {
+    background-color: #f3eded;
+}
+
+.actions {
+    display: flex;
+    gap: 16px;
+    flex-wrap: wrap;
+}
+
+.actions button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    height: 56px;
+    padding: 0 32px;
+    border-radius: 10px;
+    border: none;
+    font-weight: 700;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: opacity 0.2s;
+}
+
+.approveButton {
+    background-color: #207868;
+    color: #ffffff;
+}
+
+.approveButton:hover {
+    opacity: 0.9;
+}
+
+.cancelButton {
+    background-color: #fc0;
+    color: #111827;
+}
+
+.cancelButton:hover {
+    opacity: 0.9;
+}
+
+.completeButton {
+    background-color: #207868;
+    color: #ffffff;
+    opacity: 0.4;
+    cursor: not-allowed;
+}

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -12,6 +12,7 @@ import ListagemUsuarios from './pages/app/ListagemUsuarios/ListagemUsuarios.jsx'
 import Dashboard from './pages/app/Dashboard/Dashboard.jsx'
 import PaginaItem from './pages/app/PaginaItem/PaginaItem.jsx'
 import ListagemPedidos from './pages/app/ListagemPedidos/ListagemPedidos.jsx'
+import PedidoAguardandoAprovacao from './pages/app/PedidoAguardandoAprovacao/PedidoAguardandoAprovacao.jsx'
 
 function AppRoutes() {
   return (
@@ -30,6 +31,7 @@ function AppRoutes() {
         <Route path="items/novo" element={<PaginaItem />} />
         <Route path="items/:id" element={<PaginaItem />} />
         <Route path="pedidos" element={<ListagemPedidos />} />
+        <Route path="pedidos/:id" element={<PedidoAguardandoAprovacao />} />
         <Route path="usuarios" element={<ListagemUsuarios />} />
       </Route>
     </Routes>


### PR DESCRIPTION
## Summary
Implementa `PedidoAguardandoAprovacao.jsx` conforme o frame "Página de Pedido" (status "Pendente") do Figma, consultado via `get_design_context`:

- Coluna com imagem placeholder e dados do solicitante (nome + email)
- Coluna com o formulário somente leitura (item solicitado, status, data)
- 3 botões de ação: Aprovar (verde), Cancelar (amarelo), Concluir (desabilitado, só faz sentido quando o pedido já estiver aprovado)

- Estende `src/data/mockPedidos.js` com `email` e nome completo do solicitante, campos que essa tela precisa e a listagem (#37) não usava
- Conecta o botão "Ação" de cada linha da `ListagemPedidos` pra navegar até `/app/pedidos/:id` (antes era inerte)
- Aprovar/Cancelar não persistem nada ainda, só navegam de volta pra listagem, isso é escopo da integração com a API (#44)

## Observação para a #39 (Pedido Aguardando Conclusão)
Por enquanto a rota `/app/pedidos/:id` sempre renderiza esta tela (a de aprovação), independente do status do pedido. Quando a #39 for implementada, essa rota vai precisar decidir entre as duas telas com base no status do pedido (Pendente → esta tela, Aprovado → a nova).

Closes #38

## Test plan
- [x] `npm run lint` sem erros
- [x] `npm run build` sem erros
- [x] Conferência visual no navegador (não realizada nesta sessão, sem acesso a browser)