### PR TITLE
feat: implementar tela de Pedido Aguardando Conclusão com dados mockados

### DIFF
--- a/src/pages/app/PedidoAguardandoConclusao/PedidoAguardandoConclusao.jsx
+++ b/src/pages/app/PedidoAguardandoConclusao/PedidoAguardandoConclusao.jsx
@@ -1,10 +1,10 @@
 import { useNavigate } from 'react-router-dom';
-import styles from './PedidoAguardandoAprovacao.module.css';
+import styles from './PedidoAguardandoConclusao.module.css';
 
-export default function PedidoAguardandoAprovacao({ pedido }) {
+export default function PedidoAguardandoConclusao({ pedido }) {
     const navigate = useNavigate();
 
-    function handleAprovar() {
+    function handleConcluir() {
         // Sem persistência real ainda, isso é escopo da integração com a API (#44).
         navigate('/app/pedidos');
     }
@@ -51,7 +51,7 @@ export default function PedidoAguardandoAprovacao({ pedido }) {
             </div>
 
             <div className={styles.actions}>
-                <button type="button" className={styles.approveButton} onClick={handleAprovar}>
+                <button type="button" className={styles.approveButton} disabled>
                     <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" strokeWidth="2" fill="none">
                         <path d="M5 13l4 4L19 7" strokeLinecap="round" strokeLinejoin="round" />
                     </svg>
@@ -64,7 +64,7 @@ export default function PedidoAguardandoAprovacao({ pedido }) {
                     </svg>
                     Cancelar
                 </button>
-                <button type="button" className={styles.completeButton} disabled>
+                <button type="button" className={styles.completeButton} onClick={handleConcluir}>
                     <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" strokeWidth="2" fill="none">
                         <path d="M2 13l4 4L14 9" strokeLinecap="round" strokeLinejoin="round" />
                         <path d="M10 13l4 4L22 9" strokeLinecap="round" strokeLinejoin="round" />

--- a/src/pages/app/PedidoAguardandoConclusao/PedidoAguardandoConclusao.module.css
+++ b/src/pages/app/PedidoAguardandoConclusao/PedidoAguardandoConclusao.module.css
@@ -1,0 +1,126 @@
+.pageContainer {
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+    width: 100%;
+}
+
+.pageTitle {
+    font-size: 1.75rem;
+    font-weight: bold;
+    color: #111827;
+    margin: 0;
+}
+
+.content {
+    display: flex;
+    gap: 48px;
+    align-items: flex-start;
+    flex-wrap: wrap;
+}
+
+.mediaColumn {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    flex: 1;
+    min-width: 280px;
+    max-width: 420px;
+}
+
+.imagePlaceholder {
+    width: 100%;
+    aspect-ratio: 5 / 4;
+    background-color: #d9d9d9;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 8px;
+}
+
+.solicitanteInfo {
+    font-size: 1.1rem;
+    color: #111827;
+    line-height: 1.8;
+    margin: 0;
+}
+
+.formColumn {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    flex: 1;
+    min-width: 280px;
+    max-width: 420px;
+}
+
+.field {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.fieldLabel {
+    font-weight: 700;
+    font-size: 1.1rem;
+    color: #111827;
+}
+
+.fieldBox {
+    background-color: #ffffff;
+    border: 1px solid #ccd5dc;
+    border-radius: 10px;
+    padding: 16px 20px;
+    font-size: 1rem;
+    color: #111827;
+}
+
+.fieldBoxDisabled {
+    background-color: #f3eded;
+}
+
+.actions {
+    display: flex;
+    gap: 16px;
+    flex-wrap: wrap;
+}
+
+.actions button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    height: 56px;
+    padding: 0 32px;
+    border-radius: 10px;
+    border: none;
+    font-weight: 700;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: opacity 0.2s;
+}
+
+.approveButton {
+    background-color: #207868;
+    color: #ffffff;
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+.cancelButton {
+    background-color: #fc0;
+    color: #111827;
+}
+
+.cancelButton:hover {
+    opacity: 0.9;
+}
+
+.completeButton {
+    background-color: #207868;
+    color: #ffffff;
+}
+
+.completeButton:hover {
+    opacity: 0.9;
+}

--- a/src/pages/app/PedidoDetalhe/PedidoDetalhe.jsx
+++ b/src/pages/app/PedidoDetalhe/PedidoDetalhe.jsx
@@ -1,0 +1,19 @@
+import { useParams } from 'react-router-dom';
+import mockPedidos from '../../../data/mockPedidos.js';
+import PedidoAguardandoAprovacao from '../PedidoAguardandoAprovacao/PedidoAguardandoAprovacao.jsx';
+import PedidoAguardandoConclusao from '../PedidoAguardandoConclusao/PedidoAguardandoConclusao.jsx';
+
+export default function PedidoDetalhe() {
+    const { id } = useParams();
+    const pedido = mockPedidos.find((item) => item.id === id);
+
+    if (!pedido) {
+        return <p>Pedido não encontrado.</p>;
+    }
+
+    if (pedido.status === 'Aprovado') {
+        return <PedidoAguardandoConclusao pedido={pedido} />;
+    }
+
+    return <PedidoAguardandoAprovacao pedido={pedido} />;
+}

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -12,7 +12,7 @@ import ListagemUsuarios from './pages/app/ListagemUsuarios/ListagemUsuarios.jsx'
 import Dashboard from './pages/app/Dashboard/Dashboard.jsx'
 import PaginaItem from './pages/app/PaginaItem/PaginaItem.jsx'
 import ListagemPedidos from './pages/app/ListagemPedidos/ListagemPedidos.jsx'
-import PedidoAguardandoAprovacao from './pages/app/PedidoAguardandoAprovacao/PedidoAguardandoAprovacao.jsx'
+import PedidoDetalhe from './pages/app/PedidoDetalhe/PedidoDetalhe.jsx'
 
 function AppRoutes() {
   return (
@@ -31,7 +31,7 @@ function AppRoutes() {
         <Route path="items/novo" element={<PaginaItem />} />
         <Route path="items/:id" element={<PaginaItem />} />
         <Route path="pedidos" element={<ListagemPedidos />} />
-        <Route path="pedidos/:id" element={<PedidoAguardandoAprovacao />} />
+        <Route path="pedidos/:id" element={<PedidoDetalhe />} />
         <Route path="usuarios" element={<ListagemUsuarios />} />
       </Route>
     </Routes>


### PR DESCRIPTION
## Summary
Implementa `PedidoAguardandoConclusao.jsx` conforme o frame "Página de Pedido" (status "Aprovado") do Figma, consultado via `get_design_context`: mesmo layout da tela de aprovação (#38), mas com Aprovar desabilitado e Concluir ativo, já que o pedido já foi aprovado.

- Cria `PedidoDetalhe.jsx`, que busca o pedido pelo id e decide qual das duas telas mostrar de acordo com o status (`Aprovado` → tela de conclusão, qualquer outro status → tela de aprovação)
- Refatora `PedidoAguardandoAprovacao.jsx` pra receber o pedido já resolvido via prop, ao invés de fazer a busca internamente, resolvendo o ponto pendente registrado no PR da #38 (a rota `/app/pedidos/:id` não diferenciava o status do pedido ainda)
- Conecta `PedidoDetalhe` na rota `/app/pedidos/:id`, no lugar da tela de aprovação fixa

Concluir não persiste nada ainda, só navega de volta pra listagem, isso é escopo da integração com a API (#44).

Closes #39

## Test plan
- [x] `npm run lint` sem erros
- [x] `npm run build` sem erros
- [ ] Conferência visual no navegador (não realizada nesta sessão, sem acesso a browser)