### PR TITLE
fix: corrigir erro de lint em PaginaUsuario (setState em useEffect)

### DIFF
--- a/src/pages/app/PaginaUsuario/PaginaUsuario.jsx
+++ b/src/pages/app/PaginaUsuario/PaginaUsuario.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import styles from './PaginaUsuario.module.css';
 
@@ -18,18 +18,9 @@ export default function PaginaUsuario() {
     const { id } = useParams();
     const navigate = useNavigate();
 
-    const [usuario, setUsuario] = useState({
-        nome: '',
-        email: '',
-        role: 'USER',
-    });
-
-    useEffect(() => {
-        const usuarioEncontrado = mockUsuarios.find(u => u.id === id);
-        if (usuarioEncontrado) {
-            setUsuario(usuarioEncontrado);
-        }
-    }, [id]);
+    const [usuario, setUsuario] = useState(() => (
+        mockUsuarios.find(u => u.id === id) ?? { nome: '', email: '', role: 'USER' }
+    ));
 
     const handleChange = (e) => {
         const { name, value } = e.target;


### PR DESCRIPTION
## Summary
`npm run lint` estava quebrando (erro, não warning) em `PaginaUsuario.jsx`: o `useEffect` chamava `setUsuario()` de forma síncrona ao montar, disparando um re-render em cascata desnecessário (regra `react-hooks/set-state-in-effect`).

Substitui pelo padrão de inicializador preguiçoso do `useState` (`useState(() => ...)`), que resolve o usuário mockado direto na primeira renderização, sem efeito nem re-render extra.

Encontrado ao rodar `npm run lint` durante a implementação da #42, sem relação com ela.

## Test plan
- [x] `npm run lint` sem erros
- [x] `npm run build` sem erros