### PR TITLE
feat: implementar tela Escolher Perfil e fluxo Usuário (Minhas Solicitações)

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import logo from '../assets/logo.png'
 import menuIcon from '../assets/menu-icon.png'
 
@@ -12,10 +12,16 @@ const NAV_LINKS = [
 ]
 
 function Header() {
+  const navigate = useNavigate()
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
 
   function closeMobileMenu() {
     setMobileMenuOpen(false)
+  }
+
+  function goToEscolherPerfil() {
+    closeMobileMenu()
+    navigate('/escolher-perfil')
   }
 
   return (
@@ -67,8 +73,8 @@ function Header() {
           ))}
 
           <div className="menu__mobile-actions">
-            <button type="button" className="btn btn--primary">Entrar</button>
-            <button type="button" className="btn btn--secondary">Cadastre-se</button>
+            <button type="button" className="btn btn--primary" onClick={goToEscolherPerfil}>Entrar</button>
+            <button type="button" className="btn btn--secondary" onClick={goToEscolherPerfil}>Cadastre-se</button>
           </div>
         </ul>
 

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -87,8 +87,8 @@ function Header() {
         </ul>
 
         <div className="menu__actions">
-          <button type="button" className="btn btn--primary">Entrar</button>
-          <button type="button" className="btn btn--secondary">Cadastre-se</button>
+          <button type="button" className="btn btn--primary" onClick={goToEscolherPerfil}>Entrar</button>
+          <button type="button" className="btn btn--secondary" onClick={goToEscolherPerfil}>Cadastre-se</button>
         </div>
       </nav>
     </header>

--- a/src/layouts/UserLayout.jsx
+++ b/src/layouts/UserLayout.jsx
@@ -1,0 +1,63 @@
+import { Outlet, Link } from 'react-router-dom';
+import styles from './UserLayout.module.css';
+import logoImgSrc from '../assets/logo-full.png';
+import avatarImgSrc from '../assets/avatar.png';
+
+export function UserLayout() {
+    return (
+        <div className={styles.container}>
+            <header className={styles.header}>
+                <div className={styles.logoArea}>
+                    <img src={logoImgSrc} alt="Passe Adiante" className={styles.logoImg} />
+                </div>
+                <div className={styles.userInfo}>
+                    <div className={styles.userText}>
+                        <span className={styles.userName}>Maria</span>
+                        <span className={styles.userRole}>Receptora</span>
+                    </div>
+                    <img src={avatarImgSrc} alt="Avatar do usuário" className={styles.userAvatarImg} />
+                </div>
+            </header>
+
+            <div className={styles.layoutBody}>
+                <aside className={styles.sidebar}>
+                    <nav className={styles.nav}>
+                        <Link to="/user/minhas-solicitacoes" className={styles.navLink}>
+                            <svg className={styles.icon} viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" strokeWidth="2" fill="none">
+                                <path d="M9 17V9M12 17V5M15 17v-4" strokeLinecap="round" strokeLinejoin="round" />
+                                <rect x="3" y="3" width="18" height="18" rx="2" />
+                            </svg>
+                            Minhas Solicitações
+                        </Link>
+                        <Link to="/user/minhas-doacoes" className={styles.navLink}>
+                            <svg className={styles.icon} viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" strokeWidth="2" fill="none">
+                                <path d="M12 21C12 21 4 15.5 4 9.5C4 6.46 6.46 4 9.5 4C11.24 4 12.76 4.81 12.76 4.81C12.76 4.81 14.24 4.81 15 4.81C18.04 4.81 19.5 6.46 19.5 9.5C19.5 15.5 12 21 12 21Z" strokeLinecap="round" strokeLinejoin="round" />
+                            </svg>
+                            Minhas Doações
+                        </Link>
+                        <Link to="/user/catalogo" className={styles.navLink}>
+                            <svg className={styles.icon} viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" strokeWidth="2" fill="none">
+                                <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" strokeLinecap="round" strokeLinejoin="round" />
+                                <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2Z" strokeLinecap="round" strokeLinejoin="round" />
+                            </svg>
+                            Catálogo
+                        </Link>
+                    </nav>
+
+                    <div>
+                        <Link to="/" className={styles.logoutLink}>
+                            <svg className={styles.icon} viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" strokeWidth="2" fill="none">
+                                <path d="M5.75 9.75L14.75 9.75M12.75 11.75L14.75 9.75L12.75 7.75M10.75 13.75L10.75 16.75C10.75 17.8546 9.85457 18.75 8.75 18.75L2.75 18.75C1.64543 18.75 0.75 17.8546 0.75 16.75L0.750001 2.75C0.750001 1.64543 1.64543 0.75 2.75 0.75L8.75 0.75C9.85457 0.75 10.75 1.64543 10.75 2.75L10.75 5.75" strokeLinecap="round" />
+                            </svg>
+                            Sair
+                        </Link>
+                    </div>
+                </aside>
+
+                <main className={styles.pageContent}>
+                    <Outlet />
+                </main>
+            </div>
+        </div>
+    );
+}

--- a/src/layouts/UserLayout.module.css
+++ b/src/layouts/UserLayout.module.css
@@ -1,0 +1,138 @@
+.container {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+    width: 100vw;
+    background-color: #fafafa;
+    overflow: hidden;
+}
+
+.header {
+    width: 100%;
+    height: 80px;
+    background-color: #bfe6f2;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 40px;
+    box-sizing: border-box;
+    z-index: 20;
+}
+
+.logoArea {
+    display: flex;
+    align-items: center;
+}
+
+.logoImg {
+    max-height: 40px;
+    object-fit: contain;
+}
+
+.userInfo {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.userText {
+    text-align: right;
+}
+
+.userName {
+    display: block;
+    font-size: 0.95rem;
+    font-weight: bold;
+    color: #1f2937;
+}
+
+.userRole {
+    display: block;
+    font-size: 0.8rem;
+    color: #6b7280;
+}
+
+.userAvatarImg {
+    width: 42px;
+    height: 42px;
+    border-radius: 50%;
+    object-fit: cover;
+}
+
+.layoutBody {
+    display: flex;
+    flex: 1;
+    height: calc(100vh - 80px);
+    overflow: hidden;
+}
+
+.sidebar {
+    width: 283px;
+    background-color: #fafafa;
+    border-right: 1px solid #efefef;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    padding: 24px;
+    box-sizing: border-box;
+    flex-shrink: 0;
+    height: calc(100vh - 80px);
+}
+
+.nav {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.navLink {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 16px;
+    border-radius: 8px;
+    color: #374151;
+    text-decoration: none;
+    font-weight: 500;
+    font-size: 0.95rem;
+    transition: background-color 0.2s, color 0.2s;
+}
+
+.navLink:hover {
+    background-color: #f3f4f6;
+    color: #111827;
+}
+
+.logoutLink {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 12px;
+    border-radius: 8px;
+    color: #374151;
+    text-decoration: none;
+    font-weight: 500;
+    font-size: 0.95rem;
+    border: 1px solid #d1d5db;
+    transition: background-color 0.2s;
+}
+
+.logoutLink:hover {
+    background-color: #f3f4f6;
+}
+
+.icon {
+    width: 20px;
+    height: 20px;
+    flex-shrink: 0;
+}
+
+.pageContent {
+    flex: 1;
+    overflow-y: auto;
+    padding: 40px;
+    background-color: #fafafa;
+    box-sizing: border-box;
+    height: calc(100vh - 80px);
+}

--- a/src/pages/EscolherPerfil/EscolherPerfil.jsx
+++ b/src/pages/EscolherPerfil/EscolherPerfil.jsx
@@ -1,0 +1,36 @@
+import { useNavigate } from 'react-router-dom';
+import styles from './EscolherPerfil.module.css';
+import logoImgSrc from '../../assets/logo-full.png';
+
+export default function EscolherPerfil() {
+    const navigate = useNavigate();
+
+    return (
+        <div className={styles.container}>
+            <header className={styles.header}>
+                <img src={logoImgSrc} alt="Passe Adiante" className={styles.logoImg} />
+            </header>
+
+            <main className={styles.content}>
+                <h1 className={styles.title}>Escolha um perfil de acesso</h1>
+
+                <div className={styles.buttonsRow}>
+                    <button
+                        type="button"
+                        className={styles.profileButton}
+                        onClick={() => navigate('/user/minhas-solicitacoes')}
+                    >
+                        Usuário comum
+                    </button>
+                    <button
+                        type="button"
+                        className={styles.profileButton}
+                        onClick={() => navigate('/app/dashboard')}
+                    >
+                        Usuário admin
+                    </button>
+                </div>
+            </main>
+        </div>
+    );
+}

--- a/src/pages/EscolherPerfil/EscolherPerfil.module.css
+++ b/src/pages/EscolherPerfil/EscolherPerfil.module.css
@@ -1,0 +1,64 @@
+.container {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+    background-color: #fafafa;
+}
+
+.header {
+    width: 100%;
+    height: 80px;
+    background-color: #bfe6f2;
+    display: flex;
+    align-items: center;
+    padding: 0 40px;
+    box-sizing: border-box;
+}
+
+.logoImg {
+    max-height: 40px;
+    object-fit: contain;
+}
+
+.content {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 40px;
+    padding: 40px;
+}
+
+.title {
+    font-size: 2rem;
+    font-weight: 700;
+    color: #1e1e1e;
+    text-align: center;
+    margin: 0;
+}
+
+.buttonsRow {
+    display: flex;
+    gap: 32px;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+.profileButton {
+    min-width: 220px;
+    padding: 16px 32px;
+    background-color: #1e6b5c;
+    color: #ffffff;
+    border: none;
+    border-radius: 10px;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
+    transition: background-color 0.2s;
+}
+
+.profileButton:hover {
+    background-color: #154c41;
+}

--- a/src/pages/user/MinhasSolicitacoes/MinhasSolicitacoes.jsx
+++ b/src/pages/user/MinhasSolicitacoes/MinhasSolicitacoes.jsx
@@ -1,0 +1,86 @@
+import { useState } from 'react';
+import styles from './MinhasSolicitacoes.module.css';
+
+const STATUS_OPTIONS = ['TODAS', 'PENDENTE', 'APROVADO', 'RECUSADO', 'CONCLUÍDO'];
+
+const mockSolicitacoes = [
+    { id: 1, item: 'Kit de Livros Didáticos - 5° Ano (Ensino Fundamental)', doador: 'M. Oliveira', status: 'PENDENTE' },
+    { id: 2, item: 'Mochila Escolar Reforçada', doador: 'R. Bezerra', status: 'APROVADO' },
+    { id: 3, item: 'Coleção de Livros Didáticos', doador: 'S. Ferreira', status: 'RECUSADO' },
+    { id: 4, item: 'Kit de Lápis de Cor 48un.', doador: 'A. Beatriz', status: 'CONCLUÍDO' },
+    { id: 5, item: 'Estojo Escolar', doador: 'L. Martins', status: 'PENDENTE' },
+];
+
+export default function MinhasSolicitacoes() {
+    const [searchTerm, setSearchTerm] = useState('');
+    const [statusFilter, setStatusFilter] = useState('TODAS');
+
+    const filteredSolicitacoes = mockSolicitacoes.filter((solicitacao) => {
+        const matchesSearch = solicitacao.item.toLowerCase().includes(searchTerm.toLowerCase());
+        const matchesStatus = statusFilter === 'TODAS' || solicitacao.status === statusFilter;
+        return matchesSearch && matchesStatus;
+    });
+
+    return (
+        <div className={styles.pageContainer}>
+            <h1 className={styles.pageTitle}>Minhas Solicitações</h1>
+
+            <div className={styles.filtersRow}>
+                <input
+                    type="text"
+                    placeholder="Buscar por nome do item"
+                    value={searchTerm}
+                    onChange={(event) => setSearchTerm(event.target.value)}
+                    className={styles.searchInput}
+                />
+
+                <div className={styles.statusField}>
+                    <label htmlFor="status-filter">Status da Solicitação</label>
+                    <select
+                        id="status-filter"
+                        value={statusFilter}
+                        onChange={(event) => setStatusFilter(event.target.value)}
+                        className={styles.statusSelect}
+                    >
+                        {STATUS_OPTIONS.map((option) => (
+                            <option key={option} value={option}>{option}</option>
+                        ))}
+                    </select>
+                </div>
+            </div>
+
+            {filteredSolicitacoes.length > 0 ? (
+                <div className={styles.grid}>
+                    {filteredSolicitacoes.map((solicitacao) => (
+                        <article key={solicitacao.id} className={styles.card}>
+                            <div className={styles.cardImage} />
+                            <div className={styles.cardContent}>
+                                <h2 className={styles.cardTitle}>{solicitacao.item}</h2>
+                                <p className={styles.cardDonor}>
+                                    <strong>Doador:</strong> {solicitacao.doador}
+                                </p>
+
+                                <span className={`${styles.badge} ${styles[`badge${solicitacao.status.replace('Í', 'I')}`]}`}>
+                                    {solicitacao.status}
+                                </span>
+
+                                {solicitacao.status === 'PENDENTE' && (
+                                    <button type="button" className={styles.cancelButton}>
+                                        Cancelar Pedido
+                                    </button>
+                                )}
+                                {solicitacao.status === 'APROVADO' && (
+                                    <button type="button" className={styles.confirmButton}>
+                                        Confirmar Entrega
+                                    </button>
+                                )}
+                            </div>
+                        </article>
+                    ))}
+                </div>
+            ) : (
+                <p className={styles.emptyState}>Nenhuma solicitação encontrada.</p>
+            )}
+        </div>
+    );
+}

--- a/src/pages/user/MinhasSolicitacoes/MinhasSolicitacoes.module.css
+++ b/src/pages/user/MinhasSolicitacoes/MinhasSolicitacoes.module.css
@@ -1,0 +1,165 @@
+.pageContainer {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    width: 100%;
+}
+
+.pageTitle {
+    font-size: 1.5rem;
+    font-weight: bold;
+    color: #111827;
+    margin: 0;
+}
+
+.filtersRow {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 24px;
+    flex-wrap: wrap;
+}
+
+.searchInput {
+    flex: 1;
+    min-width: 260px;
+    padding: 12px 16px;
+    border: 1.5px solid #e5e7ea;
+    border-radius: 12px;
+    background-color: #f9fafb;
+    font-size: 1rem;
+    outline: none;
+}
+
+.searchInput:focus {
+    border-color: #1e6b5c;
+    background-color: #ffffff;
+}
+
+.statusField {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.statusField label {
+    font-size: 0.95rem;
+    font-weight: 500;
+    color: #131927;
+}
+
+.statusSelect {
+    min-width: 200px;
+    padding: 12px 16px;
+    border: 1.5px solid #e5e7ea;
+    border-radius: 12px;
+    background-color: #f9fafb;
+    font-size: 1rem;
+    outline: none;
+}
+
+.grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: 24px;
+}
+
+.card {
+    background-color: #ffffff;
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 4px 10px -4px rgba(19, 25, 39, 0.12), 0 7px 23px -3px rgba(19, 25, 39, 0.1);
+    display: flex;
+    flex-direction: column;
+}
+
+.cardImage {
+    background-color: #d9d9d9;
+    aspect-ratio: 16 / 10;
+    width: 100%;
+}
+
+.cardContent {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 16px;
+}
+
+.cardTitle {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: #131927;
+    margin: 0;
+}
+
+.cardDonor {
+    font-size: 0.85rem;
+    color: #6d717f;
+    margin: 0;
+}
+
+.badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 3px 10px;
+    border-radius: 5px;
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: #ffffff;
+}
+
+.badgePENDENTE {
+    background-color: #fa0;
+}
+
+.badgeAPROVADO {
+    background-color: #43b75d;
+}
+
+.badgeRECUSADO {
+    background-color: #ee443f;
+}
+
+.badgeCONCLUIDO {
+    background-color: #078c5b;
+}
+
+.cancelButton {
+    width: 100%;
+    padding: 10px 14px;
+    background: none;
+    border: 1px solid #ee443f;
+    border-radius: 8px;
+    color: #ee443f;
+    font-weight: 600;
+    font-size: 0.85rem;
+    cursor: pointer;
+}
+
+.cancelButton:hover {
+    background-color: rgba(238, 68, 63, 0.08);
+}
+
+.confirmButton {
+    width: 100%;
+    padding: 10px 14px;
+    background: none;
+    border: 1px solid #43b75d;
+    border-radius: 8px;
+    color: #43b75d;
+    font-weight: 600;
+    font-size: 0.85rem;
+    cursor: pointer;
+}
+
+.confirmButton:hover {
+    background-color: rgba(67, 183, 93, 0.08);
+}
+
+.emptyState {
+    text-align: center;
+    color: #6d717f;
+    padding: 40px 0;
+}

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -15,6 +15,10 @@ import PaginaItem from './pages/app/PaginaItem/PaginaItem.jsx'
 import ListagemPedidos from './pages/app/ListagemPedidos/ListagemPedidos.jsx'
 import PedidoDetalhe from './pages/app/PedidoDetalhe/PedidoDetalhe.jsx'
 
+import EscolherPerfil from './pages/EscolherPerfil/EscolherPerfil.jsx'
+import { UserLayout } from './layouts/UserLayout.jsx'
+import MinhasSolicitacoes from './pages/user/MinhasSolicitacoes/MinhasSolicitacoes.jsx'
+
 function AppRoutes() {
   return (
     <Routes>
@@ -35,6 +39,14 @@ function AppRoutes() {
         <Route path="pedidos/:id" element={<PedidoDetalhe />} />
         <Route path="usuarios" element={<ListagemUsuarios />} />
         <Route path="usuarios/:id" element={<PaginaUsuario />} />
+      </Route>
+
+      <Route path="/escolher-perfil" element={<EscolherPerfil />} />
+
+      <Route path="/user" element={<UserLayout />}>
+        <Route path="minhas-solicitacoes" element={<MinhasSolicitacoes />} />
+        <Route path="minhas-doacoes" element={<h1>Minhas Doações</h1>} />
+        <Route path="catalogo" element={<h1>Catálogo</h1>} />
       </Route>
     </Routes>
   )


### PR DESCRIPTION
## Summary
Consultado via `get_design_context` nos frames `[ESCOLHER PERFIL]` (node-id 437:4841) e `[USER] Minhas Solicitações` (node-id 120:3759) do Figma.

- `EscolherPerfil.jsx`: tela com dois botões (Usuário comum/Usuário admin), header próprio minimalista (sem nav, sem avatar, já que ninguém está autenticado ainda)
  - "Usuário admin" → `/app/dashboard` (fluxo já existente)
  - "Usuário comum" → `/user/minhas-solicitacoes` (fluxo novo)
- Conecta os 4 botões "Entrar"/"Cadastre-se" do Header do site (desktop e mobile) pra navegar até `/escolher-perfil`, antes eram inertes
- `UserLayout.jsx`: layout paralelo ao `AppLayout` do admin, mesma estrutura (header + sidebar + Outlet), com os itens de menu do fluxo Usuário
- `MinhasSolicitacoes.jsx`: busca por nome do item, filtro por status, grid de cards com badge de status e botão de ação condicional (Cancelar Pedido/Confirmar Entrega/nenhum), dados mockados
- Rotas placeholder para `/user/minhas-doacoes` e `/user/catalogo`

<img width="1869" height="922" alt="image" src="https://github.com/user-attachments/assets/a7fad2c5-e252-423c-b5e4-03a865dae4ce" />


## Fora de escopo (fica pra depois do MVP, conforme a issue)
Login/autenticação de verdade, cadastro de usuário, demais telas do fluxo Usuário, fluxo Admin completo além do Dashboard. Por enquanto é só navegação entre dois perfis fixos, sem persistir estado nem validar nada.

Closes #74

## Test plan
- [x] `npm run lint` sem erros nos arquivos novos (o erro pré-existente em `PaginaUsuario.jsx` já está sendo corrigido no PR #73, não relacionado)
- [x] `npm run build` sem erros
- [x] Conferência visual no navegador (não realizada nesta sessão, sem acesso a browser)