### PR TITLE
feat: integrar telas de Usuários com a API do NestJS

### DIFF
--- a/src/data/userOptions.js
+++ b/src/data/userOptions.js
@@ -1,0 +1,10 @@
+export const typeOptions = [
+    { value: 'ADMIN', label: 'Admin' },
+    { value: 'DONOR', label: 'Doador' },
+    { value: 'RECEIVER', label: 'Receptor' },
+    { value: 'INSTITUTION', label: 'Instituição' },
+];
+
+export function typeLabel(value) {
+    return typeOptions.find((option) => option.value === value)?.label ?? value;
+}

--- a/src/pages/app/ListagemUsuarios/ListagemUsuarios.jsx
+++ b/src/pages/app/ListagemUsuarios/ListagemUsuarios.jsx
@@ -1,28 +1,40 @@
-import { useState } from 'react';
-import styles from './ListagemUsuarios.module.css';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-
-const mockUsuarios = [
-    { id: 1, nome: 'Jorge Augusto', email: 'jaug.braga@gmail.com', role: 'User' },
-    { id: 2, nome: 'Lara Santana', email: 'laurinha23@hotmail.com', role: 'User' },
-    { id: 3, nome: 'Marcelo Antônio', email: 'marquinhosilva@gmail.com', role: 'User' },
-    { id: 4, nome: 'Lucas Vieira', email: 'luvi@yahoo.com.br', role: 'User' },
-    { id: 5, nome: 'Ana Maria Moura', email: 'ana.mounra@passeadiante.com', role: 'ADMIN' },
-    { id: 6, nome: 'Maria Aparecida Lima', email: 'mapa_lima@gmail.com', role: 'User' },
-    { id: 7, nome: 'Julio Antonio Arara', email: 'ju_arara@yahoo.com.br', role: 'User' },
-    { id: 8, nome: 'Laura Maria das Neves', email: 'laura.neves@passeadiante.com', role: 'ADMIN' },
-    { id: 9, nome: 'Laura Maria das Neves', email: 'laura.neves@passeadiante.com', role: 'User' },
-];
+import styles from './ListagemUsuarios.module.css';
+import { listUsers } from '../../../services/usersService.js';
+import { typeLabel } from '../../../data/userOptions.js';
 
 const USERS_PER_PAGE = 5;
 
 export default function ListagemUsuarios() {
     const navigate = useNavigate();
+    const [usuarios, setUsuarios] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
     const [searchTerm, setSearchTerm] = useState('');
     const [currentPage, setCurrentPage] = useState(1);
 
-    const filteredUsuarios = mockUsuarios.filter(user =>
-        user.nome.toLowerCase().includes(searchTerm.toLowerCase()) ||
+    useEffect(() => {
+        let cancelled = false;
+
+        listUsers()
+            .then((data) => {
+                if (!cancelled) setUsuarios(data);
+            })
+            .catch(() => {
+                if (!cancelled) setError('Não foi possível carregar os usuários.');
+            })
+            .finally(() => {
+                if (!cancelled) setLoading(false);
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    const filteredUsuarios = usuarios.filter(user =>
+        user.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
         user.email.toLowerCase().includes(searchTerm.toLowerCase())
     );
 
@@ -65,6 +77,8 @@ export default function ListagemUsuarios() {
                 </div>
             </div>
 
+            {error && <p className={styles.errorMessage}>{error}</p>}
+
             <div className={styles.card}>
                 <div className={styles.tableWrapper}>
                     <table className={styles.table}>
@@ -77,18 +91,24 @@ export default function ListagemUsuarios() {
                                     E-mail <span className={styles.sortIcon}>↕</span>
                                 </th>
                                 <th>
-                                    Role <span className={styles.sortIcon}>↕</span>
+                                    Tipo <span className={styles.sortIcon}>↕</span>
                                 </th>
                                 <th>Ação</th>
                             </tr>
                         </thead>
                         <tbody>
-                            {currentUsuarios.length > 0 ? (
+                            {loading ? (
+                                <tr>
+                                    <td colSpan="4" style={{ textAlign: 'center', padding: '24px', color: '#6b7280' }}>
+                                        Carregando usuários...
+                                    </td>
+                                </tr>
+                            ) : currentUsuarios.length > 0 ? (
                                 currentUsuarios.map((user) => (
                                     <tr key={user.id} className={styles.tableRow}>
-                                        <td>{user.nome}</td>
+                                        <td>{user.name}</td>
                                         <td>{user.email}</td>
-                                        <td>{user.role}</td>
+                                        <td>{typeLabel(user.type)}</td>
                                         <td>
                                             <button
                                                 className={styles.actionBtn}

--- a/src/pages/app/ListagemUsuarios/ListagemUsuarios.module.css
+++ b/src/pages/app/ListagemUsuarios/ListagemUsuarios.module.css
@@ -18,6 +18,16 @@
     margin: 0;
 }
 
+.errorMessage {
+    background-color: #fef2f2;
+    color: #b91c1c;
+    border: 1px solid #fecaca;
+    border-radius: 8px;
+    padding: 12px 16px;
+    font-size: 0.9rem;
+    margin: 0;
+}
+
 .filterRow {
     display: flex;
     align-items: center;

--- a/src/pages/app/PaginaUsuario/PaginaUsuario.jsx
+++ b/src/pages/app/PaginaUsuario/PaginaUsuario.jsx
@@ -1,26 +1,46 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import styles from './PaginaUsuario.module.css';
+import { getUser, updateUser, deleteUser } from '../../../services/usersService.js';
+import { typeOptions } from '../../../data/userOptions.js';
 
-const mockUsuarios = [
-    { id: '1', nome: 'Jorge Augusto', email: 'jaug.braga@gmail.com', role: 'User' },
-    { id: '2', nome: 'Lara Santana', email: 'laurinha23@hotmail.com', role: 'User' },
-    { id: '3', nome: 'Marcelo Antônio', email: 'marquinhosilva@gmail.com', role: 'User' },
-    { id: '4', nome: 'Lucas Vieira', email: 'luvi@yahoo.com.br', role: 'User' },
-    { id: '5', nome: 'Ana Maria Moura', email: 'ana.mounra@passeadiante.com', role: 'ADMIN' },
-    { id: '6', nome: 'Maria Aparecida Lima', email: 'mapa_lima@gmail.com', role: 'User' },
-    { id: '7', nome: 'Julio Antonio Arara', email: 'ju_arara@yahoo.com.br', role: 'User' },
-    { id: '8', nome: 'Laura Maria das Neves', email: 'laura.neves@passeadiante.com', role: 'ADMIN' },
-    { id: '9', nome: 'Laura Maria das Neves', email: 'laura.neves@passeadiante.com', role: 'User' },
-];
+const emptyUsuario = { name: '', email: '', type: typeOptions[0].value, phones: '', address: '' };
 
 export default function PaginaUsuario() {
     const { id } = useParams();
     const navigate = useNavigate();
 
-    const [usuario, setUsuario] = useState(() => (
-        mockUsuarios.find(u => u.id === id) ?? { nome: '', email: '', role: 'USER' }
-    ));
+    const [usuario, setUsuario] = useState(emptyUsuario);
+    const [loading, setLoading] = useState(true);
+    const [saving, setSaving] = useState(false);
+    const [error, setError] = useState(null);
+
+    useEffect(() => {
+        let cancelled = false;
+
+        getUser(id)
+            .then((data) => {
+                if (!cancelled) {
+                    setUsuario({
+                        name: data.name ?? '',
+                        email: data.email,
+                        type: data.type,
+                        phones: (data.phones ?? []).join(', '),
+                        address: data.address ?? '',
+                    });
+                }
+            })
+            .catch(() => {
+                if (!cancelled) setError('Não foi possível carregar o usuário.');
+            })
+            .finally(() => {
+                if (!cancelled) setLoading(false);
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [id]);
 
     const handleChange = (e) => {
         const { name, value } = e.target;
@@ -29,18 +49,49 @@ export default function PaginaUsuario() {
 
     const handleSave = (e) => {
         e.preventDefault();
-        console.log('Salvando alterações do usuário ID:', id, usuario);
-        navigate('/app/usuarios');
+        setSaving(true);
+        setError(null);
+
+        const payload = {
+            name: usuario.name,
+            email: usuario.email,
+            type: usuario.type,
+            phones: usuario.phones.split(',').map((phone) => phone.trim()).filter(Boolean),
+            address: usuario.address || undefined,
+        };
+
+        updateUser(id, payload)
+            .then(() => navigate('/app/usuarios'))
+            .catch(() => {
+                setError('Não foi possível salvar as alterações.');
+                setSaving(false);
+            });
     };
 
     const handleDelete = () => {
-        console.log('Excluir usuário ID:', id);
-        navigate('/app/usuarios');
+        setSaving(true);
+        setError(null);
+        deleteUser(id)
+            .then(() => navigate('/app/usuarios'))
+            .catch(() => {
+                setError('Não foi possível excluir o usuário.');
+                setSaving(false);
+            });
     };
+
+    if (loading) {
+        return (
+            <div className={styles.pageContainer}>
+                <p>Carregando...</p>
+            </div>
+        );
+    }
 
     return (
         <div className={styles.pageContainer}>
             <h2 className={styles.pageTitle}>Página de Usuário</h2>
+
+            {error && <p className={styles.errorMessage}>{error}</p>}
 
             <div className={styles.card}>
                 <form onSubmit={handleSave} className={styles.formContent}>
@@ -65,8 +116,8 @@ export default function PaginaUsuario() {
                             <label className={styles.label}>Nome:</label>
                             <input
                                 type="text"
-                                name="nome"
-                                value={usuario.nome}
+                                name="name"
+                                value={usuario.name}
                                 onChange={handleChange}
                                 className={styles.input}
                             />
@@ -84,16 +135,39 @@ export default function PaginaUsuario() {
                         </div>
 
                         <div className={styles.inputGroup}>
-                            <label className={styles.label}>Role:</label>
+                            <label className={styles.label}>Telefones (separados por vírgula):</label>
+                            <input
+                                type="text"
+                                name="phones"
+                                value={usuario.phones}
+                                onChange={handleChange}
+                                className={styles.input}
+                            />
+                        </div>
+
+                        <div className={styles.inputGroup}>
+                            <label className={styles.label}>Endereço:</label>
+                            <input
+                                type="text"
+                                name="address"
+                                value={usuario.address}
+                                onChange={handleChange}
+                                className={styles.input}
+                            />
+                        </div>
+
+                        <div className={styles.inputGroup}>
+                            <label className={styles.label}>Tipo:</label>
                             <div className={styles.selectWrapper}>
                                 <select
-                                    name="role"
-                                    value={usuario.role}
+                                    name="type"
+                                    value={usuario.type}
                                     onChange={handleChange}
                                     className={styles.select}
                                 >
-                                    <option value="USER">USER</option>
-                                    <option value="ADMIN">ADMIN</option>
+                                    {typeOptions.map((option) => (
+                                        <option key={option.value} value={option.value}>{option.label}</option>
+                                    ))}
                                 </select>
                                 <svg className={styles.selectArrow} viewBox="0 0 24 24" width="18" height="18" stroke="currentColor" strokeWidth="2" fill="none">
                                     <polyline points="6 9 12 15 18 9" strokeLinecap="round" strokeLinejoin="round" />
@@ -104,20 +178,20 @@ export default function PaginaUsuario() {
                 </form>
 
                 <div className={styles.actionsFooter}>
-                    <button type="button" onClick={handleDelete} className={styles.deleteButton}>
+                    <button type="button" onClick={handleDelete} className={styles.deleteButton} disabled={saving}>
                         <svg viewBox="0 0 24 24" width="18" height="18" stroke="currentColor" strokeWidth="2" fill="none">
                             <polyline points="3 6 5 6 21 6" strokeLinecap="round" strokeLinejoin="round" />
                             <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" strokeLinecap="round" strokeLinejoin="round" />
                         </svg>
                         Excluir Usuário
                     </button>
-                    <button type="button" onClick={handleSave} className={styles.saveButton}>
+                    <button type="button" onClick={handleSave} className={styles.saveButton} disabled={saving}>
                         <svg viewBox="0 0 24 24" width="18" height="18" stroke="currentColor" strokeWidth="2" fill="none">
                             <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z" strokeLinecap="round" strokeLinejoin="round" />
                             <polyline points="17 21 17 13 7 13 7 21" strokeLinecap="round" strokeLinejoin="round" />
                             <polyline points="7 3 7 8 15 8" strokeLinecap="round" strokeLinejoin="round" />
                         </svg>
-                        Salvar Alterações
+                        {saving ? 'Salvando...' : 'Salvar Alterações'}
                     </button>
                 </div>
             </div>

--- a/src/pages/app/PaginaUsuario/PaginaUsuario.module.css
+++ b/src/pages/app/PaginaUsuario/PaginaUsuario.module.css
@@ -12,6 +12,16 @@
     margin: 0;
 }
 
+.errorMessage {
+    background-color: #fef2f2;
+    color: #b91c1c;
+    border: 1px solid #fecaca;
+    border-radius: 8px;
+    padding: 12px 16px;
+    font-size: 0.9rem;
+    margin: 0;
+}
+
 .card {
     background-color: #ffffff;
     border-radius: 12px;

--- a/src/services/usersService.js
+++ b/src/services/usersService.js
@@ -3,3 +3,15 @@ import api from './api.js';
 export function listUsers() {
     return api.get('/user/list').then((response) => response.data);
 }
+
+export function getUser(id) {
+    return api.get(`/user/${id}`).then((response) => response.data);
+}
+
+export function updateUser(id, data) {
+    return api.patch(`/user/${id}`, data).then((response) => response.data);
+}
+
+export function deleteUser(id) {
+    return api.delete(`/user/${id}`).then((response) => response.data);
+}


### PR DESCRIPTION
## Summary
Estende `src/services/usersService.js` (já existia `listUsers`, da `#43`) com `getUser`, `updateUser` e `deleteUser`.

- `ListagemUsuarios.jsx` busca usuários reais via `GET /user/list`, com loading/erro. Coluna "Role" virou "Tipo", mostrando o enum real (Admin/Doador/Receptor/Instituição) em vez do texto livre `User`/`ADMIN` do mock
- `PaginaUsuario.jsx` busca o usuário via `GET /user/:id`, edita via `PATCH /user/:id` (nome, email, telefones, endereço, tipo) e exclui via `DELETE /user/:id`, todos com loading e mensagem de erro

## Mudança de modelo
O mock usava só nome/email/role (`User`/`ADMIN`). O schema real tem `type` (enum `ADMIN`/`DONOR`/`RECEIVER`/`INSTITUTION`), `phones` (array) e `address`, que não existiam nos dados mockados. Adicionei campos de telefone (texto separado por vírgula, convertido pra array no submit) e endereço ao formulário, e troquei o seletor de role pros 4 valores reais do enum.

Não testei a exclusão de usuário nesta sessão, pra não apagar o usuário de teste usado nas issues `#43`/`#44`/`#46`/`#47`. `list`, `get` e `update` foram testados contra o back real.

Closes #45

## Test plan
- [x] `npm run lint` sem erros
- [x] `npm run build` sem erros
- [x] Testado manualmente contra o back real: listar, buscar por id e editar usuário