### PR TITLE
fix: tornar a logo clicável na tela Escolher Perfil

### DIFF
--- a/src/pages/EscolherPerfil/EscolherPerfil.jsx
+++ b/src/pages/EscolherPerfil/EscolherPerfil.jsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import styles from './EscolherPerfil.module.css';
 import logoImgSrc from '../../assets/logo-full.png';
 
@@ -8,7 +8,9 @@ export default function EscolherPerfil() {
     return (
         <div className={styles.container}>
             <header className={styles.header}>
-                <img src={logoImgSrc} alt="Passe Adiante" className={styles.logoImg} />
+                <Link to="/">
+                    <img src={logoImgSrc} alt="Passe Adiante" className={styles.logoImg} />
+                </Link>
             </header>
 
             <main className={styles.content}>


### PR DESCRIPTION
## Summary
A logo do header (Passe Adiante) na tela `/escolher-perfil` não era clicável. Envolve a imagem num `Link` do react-router para `/`, levando de volta pra Home do site ao clicar.

Conferência visual fica coberta pela issue de QA #84.

## Test plan
- [x] `npm run lint` sem erros
- [x] `npm run build` sem erros