### PR TITLE
feat: integrar Dashboard com a API do NestJS

### DIFF
--- a/src/pages/app/Dashboard/Dashboard.jsx
+++ b/src/pages/app/Dashboard/Dashboard.jsx
@@ -1,25 +1,64 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import styles from './Dashboard.module.css';
+import { listUsers } from '../../../services/usersService.js';
+import { listItems } from '../../../services/itemsService.js';
+import { listOrders } from '../../../services/ordersService.js';
+import { statusLabel } from '../../../data/orderOptions.js';
 
-const stats = [
-    { id: 1, value: 120, label: 'Total de Usuários', variant: styles.statCardDark },
-    { id: 2, value: 340, label: 'Total de Itens', variant: styles.statCardBlue },
-    { id: 3, value: 12, label: 'Pedidos Pendentes', variant: styles.statCardGreen },
-    { id: 4, value: 210, label: 'Itens Disponíveis', variant: styles.statCardCyan },
-];
-
-const ultimosPedidos = [
-    { id: '01', usuario: 'João', item: 'Livro', status: 'Pendente', data: '12/05/25' },
-    { id: '02', usuario: 'Maria', item: 'Mochila', status: 'Aprovado', data: '13/05/25' },
-    { id: '03', usuario: 'Clara', item: 'Estojo', status: 'Recusado', data: '11/05/25' },
-];
+const ULTIMOS_PEDIDOS_LIMIT = 5;
 
 export default function Dashboard() {
+    const navigate = useNavigate();
+    const [users, setUsers] = useState([]);
+    const [items, setItems] = useState([]);
+    const [orders, setOrders] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+
+    useEffect(() => {
+        let cancelled = false;
+
+        Promise.all([listUsers(), listItems(), listOrders()])
+            .then(([usersData, itemsData, ordersData]) => {
+                if (!cancelled) {
+                    setUsers(usersData);
+                    setItems(itemsData);
+                    setOrders(ordersData);
+                }
+            })
+            .catch(() => {
+                if (!cancelled) setError('Não foi possível carregar os dados do dashboard.');
+            })
+            .finally(() => {
+                if (!cancelled) setLoading(false);
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    const stats = [
+        { id: 1, value: users.length, label: 'Total de Usuários', variant: styles.statCardDark },
+        { id: 2, value: items.length, label: 'Total de Itens', variant: styles.statCardBlue },
+        { id: 3, value: orders.filter((order) => order.status === 'PENDING').length, label: 'Pedidos Pendentes', variant: styles.statCardGreen },
+        { id: 4, value: items.filter((item) => item.availability === 'AVAILABLE').length, label: 'Itens Disponíveis', variant: styles.statCardCyan },
+    ];
+
+    // O model Order não tem campo de data (createdAt/updatedAt), então não há como
+    // ordenar por "mais recente" de verdade. Mostra os primeiros N pedidos retornados
+    // pela API como aproximação.
+    const ultimosPedidos = orders.slice(0, ULTIMOS_PEDIDOS_LIMIT);
+
     return (
         <div className={styles.pageContainer}>
+            {error && <p className={styles.errorMessage}>{error}</p>}
+
             <div className={styles.statsRow}>
                 {stats.map((stat) => (
                     <div className={`${styles.statCard} ${stat.variant}`} key={stat.id}>
-                        <span className={styles.statValue}>{stat.value}</span>
+                        <span className={styles.statValue}>{loading ? '—' : stat.value}</span>
                         <span className={styles.statLabel}>{stat.label}</span>
                     </div>
                 ))}
@@ -32,32 +71,46 @@ export default function Dashboard() {
                     <table className={styles.table}>
                         <thead>
                             <tr className={styles.tableHeader}>
-                                <th>ID</th>
                                 <th>Usuário</th>
                                 <th>Item</th>
                                 <th>Status</th>
-                                <th>Data</th>
                                 <th>Ação</th>
                             </tr>
                         </thead>
                         <tbody>
-                            {ultimosPedidos.map((pedido) => (
-                                <tr className={styles.tableRow} key={pedido.id}>
-                                    <td>{pedido.id}</td>
-                                    <td>{pedido.usuario}</td>
-                                    <td>{pedido.item}</td>
-                                    <td>{pedido.status}</td>
-                                    <td>{pedido.data}</td>
-                                    <td>
-                                        <button className={styles.actionBtn} title="Visualizar">
-                                            <svg viewBox="0 0 24 24" width="18" height="18" stroke="currentColor" strokeWidth="2" fill="none">
-                                                <circle cx="11" cy="11" r="8" stroke="#374151" strokeWidth="1.5" />
-                                                <line x1="21" y1="21" x2="16.65" y2="16.65" stroke="#374151" strokeWidth="1.5" strokeLinecap="round" />
-                                            </svg>
-                                        </button>
+                            {loading ? (
+                                <tr>
+                                    <td colSpan="4" style={{ textAlign: 'center', padding: '24px', color: '#6b7280' }}>
+                                        Carregando...
                                     </td>
                                 </tr>
-                            ))}
+                            ) : ultimosPedidos.length > 0 ? (
+                                ultimosPedidos.map((pedido) => (
+                                    <tr className={styles.tableRow} key={pedido.id}>
+                                        <td>{pedido.user.name}</td>
+                                        <td>{pedido.item.name}</td>
+                                        <td>{statusLabel(pedido.status)}</td>
+                                        <td>
+                                            <button
+                                                className={styles.actionBtn}
+                                                title="Visualizar"
+                                                onClick={() => navigate(`/app/pedidos/${pedido.id}`)}
+                                            >
+                                                <svg viewBox="0 0 24 24" width="18" height="18" stroke="currentColor" strokeWidth="2" fill="none">
+                                                    <circle cx="11" cy="11" r="8" stroke="#374151" strokeWidth="1.5" />
+                                                    <line x1="21" y1="21" x2="16.65" y2="16.65" stroke="#374151" strokeWidth="1.5" strokeLinecap="round" />
+                                                </svg>
+                                            </button>
+                                        </td>
+                                    </tr>
+                                ))
+                            ) : (
+                                <tr>
+                                    <td colSpan="4" style={{ textAlign: 'center', padding: '24px', color: '#6b7280' }}>
+                                        Nenhum pedido encontrado.
+                                    </td>
+                                </tr>
+                            )}
                         </tbody>
                     </table>
                 </div>

--- a/src/pages/app/Dashboard/Dashboard.module.css
+++ b/src/pages/app/Dashboard/Dashboard.module.css
@@ -5,6 +5,16 @@
     width: 100%;
 }
 
+.errorMessage {
+    background-color: #fef2f2;
+    color: #b91c1c;
+    border: 1px solid #fecaca;
+    border-radius: 8px;
+    padding: 12px 16px;
+    font-size: 0.9rem;
+    margin: 0;
+}
+
 .statsRow {
     display: grid;
     grid-template-columns: repeat(4, 1fr);


### PR DESCRIPTION
## Summary
Busca usuários, itens e pedidos em paralelo (`Promise.all`) via `usersService`/`itemsService`/`ordersService`, já criados nas integrações anteriores (`#43`, `#44`, `#45`).

- Cards de resumo calculados a partir dos dados reais: Total de Usuários (`users.length`), Total de Itens (`items.length`), Pedidos Pendentes (`orders` com status `PENDING`), Itens Disponíveis (`items` com `availability` `AVAILABLE`)
- Tabela "Últimos Pedidos" com os pedidos reais (usuário, item, status), botão de ação agora navega pra `/app/pedidos/:id` (antes era inerte)
- Removida a coluna "Data", mesmo motivo já registrado na `#44`: o model `Order` não tem `createdAt`/`updatedAt`
- Como não há campo de data, "Últimos Pedidos" mostra os primeiros N pedidos retornados pela API, não uma ordenação cronológica real. Documentado em comentário no código

Conferência visual fica coberta pela issue de QA #80 (já atualizada com os itens específicos dessa integração).

Closes #46

## Test plan
- [x] `npm run lint` sem erros
- [x] `npm run build` sem erros
- [x] Testado manualmente: os 4 números batem com o estado real do banco (conferido via chamadas diretas à API)