### PR TITLE
feat: corrigir responsividade da área logada (Admin/Usuário)

### DIFF
--- a/src/layouts/AppLayout.jsx
+++ b/src/layouts/AppLayout.jsx
@@ -1,14 +1,33 @@
+import { useState } from 'react';
 import { Outlet, Link } from 'react-router-dom';
 import styles from './AppLayout.module.css';
 import logoImgSrc from '../assets/logo-full.png';
 import avatarImgSrc from '../assets/avatar.png';
 
 export function AppLayout() {
+    const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
+    function closeMobileMenu() {
+        setMobileMenuOpen(false);
+    }
+
     return (
         <div className={styles.container}>
             <header className={styles.header}>
+                <button
+                    type="button"
+                    className={styles.menuToggle}
+                    aria-label="Abrir menu"
+                    onClick={() => setMobileMenuOpen(true)}
+                >
+                    <svg viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" strokeWidth="2" fill="none">
+                        <path d="M4 6h16M4 12h16M4 18h16" strokeLinecap="round" />
+                    </svg>
+                </button>
+
                 <div className={styles.logoArea}>
-                    <img src={logoImgSrc} alt="Passe Adiante" className={styles.logoImg} />                </div>
+                    <img src={logoImgSrc} alt="Passe Adiante" className={styles.logoImg} />
+                </div>
                 <div className={styles.userInfo}>
                     <div className={styles.userText}>
                         <span className={styles.userName}>Maria</span>
@@ -19,21 +38,35 @@ export function AppLayout() {
             </header>
 
             <div className={styles.layoutBody}>
-                <aside className={styles.sidebar}>
+                <div
+                    className={mobileMenuOpen ? `${styles.overlay} ${styles.overlayOpen}` : styles.overlay}
+                    onClick={closeMobileMenu}
+                />
+
+                <aside className={mobileMenuOpen ? `${styles.sidebar} ${styles.sidebarOpen}` : styles.sidebar}>
+                    <button
+                        type="button"
+                        className={styles.sidebarClose}
+                        aria-label="Fechar menu"
+                        onClick={closeMobileMenu}
+                    >
+                        &times;
+                    </button>
+
                     <nav className={styles.nav}>
-                        <Link to="/app/dashboard" className={styles.navLink}>
+                        <Link to="/app/dashboard" className={styles.navLink} onClick={closeMobileMenu}>
                             <svg className={styles.icon} viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" strokeWidth="2" fill="none">
                                 <path d="M10 21H5C3.89543 21 3 20.1046 3 19V12.2969C3 11.7852 3.19615 11.2929 3.54809 10.9215L10.5481 3.53257C11.3369 2.69989 12.663 2.69989 13.4519 3.53257L20.4519 10.9215C20.8038 11.2929 21 11.7852 21 12.2969V19C21 20.1046 20.1046 21 19 21H14M10 21V15.5C10 15.2239 10.2239 15 10.5 15H13.5C13.7761 15 14 15.2239 14 15.5V21M10 21H14" stroke="#1F1F22" stroke-width="1.5" />
                             </svg>
                             Dashboard
                         </Link>
-                        <Link to="/app/usuarios" className={styles.navLink}>
+                        <Link to="/app/usuarios" className={styles.navLink} onClick={closeMobileMenu}>
                             <svg className={styles.icon} viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" strokeWidth="2" fill="none">
                                 <path d="M5 20V19C5 15.134 8.13401 12 12 12C15.866 12 19 15.134 19 19V20" stroke="#131927" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
                                 <path d="M12 12C14.2091 12 16 10.2091 16 8C16 5.79086 14.2091 4 12 4C9.79086 4 8 5.79086 8 8C8 10.2091 9.79086 12 12 12Z" stroke="#131927" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />                            </svg>
                             Usuários
                         </Link>
-                        <Link to="/app/items" className={styles.navLink}>
+                        <Link to="/app/items" className={styles.navLink} onClick={closeMobileMenu}>
                             <svg className={styles.icon} viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" strokeWidth="2" fill="none">
                                 <path d="M16 6.27975C16 6.88118 15.7625 7.45883 15.3383 7.88611C14.3619 8.87007 13.415 9.89605 12.4021 10.8443C12.17 11.0585 11.8017 11.0507 11.5795 10.8268L8.6615 7.88611C7.7795 6.99725 7.7795 5.56225 8.6615 4.67339C9.55218 3.77579 11.0032 3.77579 11.8938 4.67339L11.9999 4.78027L12.1059 4.67345C12.533 4.24286 13.1146 4 13.7221 4C14.3297 4 14.9113 4.24284 15.3383 4.67339C15.7625 5.10073 16 5.67835 16 6.27975Z" stroke="#131927" stroke-width="1.5" stroke-linejoin="round" />
                                 <path d="M18 20L21.8243 16.1757C21.9368 16.0632 22 15.9106 22 15.7515V10.5C22 9.67157 21.3284 9 20.5 9C19.6716 9 19 9.67157 19 10.5V15" stroke="#131927" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
@@ -43,7 +76,7 @@ export function AppLayout() {
                             </svg>
                             Doações
                         </Link>
-                        <Link to="/app/pedidos" className={styles.navLink}>
+                        <Link to="/app/pedidos" className={styles.navLink} onClick={closeMobileMenu}>
                             <svg className={styles.icon} viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" strokeWidth="2" fill="none">
                                 <path d="M12 22C17.3552 22 21.7272 17.7905 21.9877 12.4999C22.0013 12.2241 21.7761 12 21.5 12H12.5C12.2239 12 12 11.7761 12 11.5V2.5C12 2.22386 11.7759 1.9987 11.5001 2.01228C6.20948 2.27276 2 6.64479 2 12C2 17.5228 6.47715 22 12 22Z" stroke="#1F1F22" stroke-width="1.5" />
                                 <path d="M21.9846 9.49991C21.7367 5.47997 18.52 2.26332 14.5001 2.01538C14.2245 1.99838 14 2.22386 14 2.5V9.5C14 9.77614 14.2239 10 14.5 10H21.5C21.7761 10 22.0016 9.77553 21.9846 9.49991Z" stroke="#1F1F22" stroke-width="1.5" />                            </svg>

--- a/src/layouts/AppLayout.module.css
+++ b/src/layouts/AppLayout.module.css
@@ -18,7 +18,17 @@
     box-sizing: border-box;
     z-index: 20;
   }
-  
+
+  .menuToggle {
+    display: none;
+    background: none;
+    border: none;
+    padding: 4px;
+    color: #1f2937;
+    cursor: pointer;
+    margin-right: 16px;
+  }
+
   .logoArea {
     display: flex;
     align-items: center;
@@ -64,8 +74,13 @@
     flex: 1;
     height: calc(100vh - 80px);
     overflow: hidden;
+    position: relative;
   }
-  
+
+  .overlay {
+    display: none;
+  }
+
   .sidebar {
     width: 280px;
     background-color: #ffffff;
@@ -78,7 +93,11 @@
     flex-shrink: 0;
     height: calc(100vh-80px);
   }
-  
+
+  .sidebarClose {
+    display: none;
+  }
+
   .nav {
     display: flex;
     flex-direction: column;
@@ -135,4 +154,66 @@
     background-color: #fcfcfc;
     box-sizing: border-box;
     height: calc(100vh-80px);
+  }
+
+  @media (max-width: 900px) {
+    .header {
+      padding: 0 16px;
+    }
+
+    .menuToggle {
+      display: flex;
+      align-items: center;
+    }
+
+    .userText {
+      display: none;
+    }
+
+    .overlay {
+      display: block;
+      position: fixed;
+      inset: 80px 0 0 0;
+      background-color: rgba(0, 0, 0, 0.4);
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.2s;
+      z-index: 25;
+    }
+
+    .overlayOpen {
+      opacity: 1;
+      pointer-events: auto;
+    }
+
+    .sidebar {
+      position: fixed;
+      top: 80px;
+      left: 0;
+      height: calc(100vh - 80px);
+      transform: translateX(-100%);
+      transition: transform 0.2s;
+      z-index: 30;
+      box-shadow: 4px 0 12px rgba(0, 0, 0, 0.1);
+    }
+
+    .sidebarOpen {
+      transform: translateX(0);
+    }
+
+    .sidebarClose {
+      display: block;
+      align-self: flex-end;
+      background: none;
+      border: none;
+      font-size: 1.75rem;
+      line-height: 1;
+      color: #374151;
+      cursor: pointer;
+      margin-bottom: 12px;
+    }
+
+    .pageContent {
+      padding: 20px;
+    }
   }

--- a/src/layouts/UserLayout.jsx
+++ b/src/layouts/UserLayout.jsx
@@ -1,12 +1,30 @@
+import { useState } from 'react';
 import { Outlet, Link } from 'react-router-dom';
 import styles from './UserLayout.module.css';
 import logoImgSrc from '../assets/logo-full.png';
 import avatarImgSrc from '../assets/avatar.png';
 
 export function UserLayout() {
+    const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
+    function closeMobileMenu() {
+        setMobileMenuOpen(false);
+    }
+
     return (
         <div className={styles.container}>
             <header className={styles.header}>
+                <button
+                    type="button"
+                    className={styles.menuToggle}
+                    aria-label="Abrir menu"
+                    onClick={() => setMobileMenuOpen(true)}
+                >
+                    <svg viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" strokeWidth="2" fill="none">
+                        <path d="M4 6h16M4 12h16M4 18h16" strokeLinecap="round" />
+                    </svg>
+                </button>
+
                 <div className={styles.logoArea}>
                     <img src={logoImgSrc} alt="Passe Adiante" className={styles.logoImg} />
                 </div>
@@ -20,22 +38,36 @@ export function UserLayout() {
             </header>
 
             <div className={styles.layoutBody}>
-                <aside className={styles.sidebar}>
+                <div
+                    className={mobileMenuOpen ? `${styles.overlay} ${styles.overlayOpen}` : styles.overlay}
+                    onClick={closeMobileMenu}
+                />
+
+                <aside className={mobileMenuOpen ? `${styles.sidebar} ${styles.sidebarOpen}` : styles.sidebar}>
+                    <button
+                        type="button"
+                        className={styles.sidebarClose}
+                        aria-label="Fechar menu"
+                        onClick={closeMobileMenu}
+                    >
+                        &times;
+                    </button>
+
                     <nav className={styles.nav}>
-                        <Link to="/user/minhas-solicitacoes" className={styles.navLink}>
+                        <Link to="/user/minhas-solicitacoes" className={styles.navLink} onClick={closeMobileMenu}>
                             <svg className={styles.icon} viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" strokeWidth="2" fill="none">
                                 <path d="M9 17V9M12 17V5M15 17v-4" strokeLinecap="round" strokeLinejoin="round" />
                                 <rect x="3" y="3" width="18" height="18" rx="2" />
                             </svg>
                             Minhas Solicitações
                         </Link>
-                        <Link to="/user/minhas-doacoes" className={styles.navLink}>
+                        <Link to="/user/minhas-doacoes" className={styles.navLink} onClick={closeMobileMenu}>
                             <svg className={styles.icon} viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" strokeWidth="2" fill="none">
                                 <path d="M12 21C12 21 4 15.5 4 9.5C4 6.46 6.46 4 9.5 4C11.24 4 12.76 4.81 12.76 4.81C12.76 4.81 14.24 4.81 15 4.81C18.04 4.81 19.5 6.46 19.5 9.5C19.5 15.5 12 21 12 21Z" strokeLinecap="round" strokeLinejoin="round" />
                             </svg>
                             Minhas Doações
                         </Link>
-                        <Link to="/user/catalogo" className={styles.navLink}>
+                        <Link to="/user/catalogo" className={styles.navLink} onClick={closeMobileMenu}>
                             <svg className={styles.icon} viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" strokeWidth="2" fill="none">
                                 <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" strokeLinecap="round" strokeLinejoin="round" />
                                 <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2Z" strokeLinecap="round" strokeLinejoin="round" />

--- a/src/layouts/UserLayout.module.css
+++ b/src/layouts/UserLayout.module.css
@@ -19,6 +19,16 @@
     z-index: 20;
 }
 
+.menuToggle {
+    display: none;
+    background: none;
+    border: none;
+    padding: 4px;
+    color: #1f2937;
+    cursor: pointer;
+    margin-right: 16px;
+}
+
 .logoArea {
     display: flex;
     align-items: center;
@@ -64,6 +74,11 @@
     flex: 1;
     height: calc(100vh - 80px);
     overflow: hidden;
+    position: relative;
+}
+
+.overlay {
+    display: none;
 }
 
 .sidebar {
@@ -77,6 +92,10 @@
     box-sizing: border-box;
     flex-shrink: 0;
     height: calc(100vh - 80px);
+}
+
+.sidebarClose {
+    display: none;
 }
 
 .nav {
@@ -135,4 +154,66 @@
     background-color: #fafafa;
     box-sizing: border-box;
     height: calc(100vh - 80px);
+}
+
+@media (max-width: 900px) {
+    .header {
+        padding: 0 16px;
+    }
+
+    .menuToggle {
+        display: flex;
+        align-items: center;
+    }
+
+    .userText {
+        display: none;
+    }
+
+    .overlay {
+        display: block;
+        position: fixed;
+        inset: 80px 0 0 0;
+        background-color: rgba(0, 0, 0, 0.4);
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.2s;
+        z-index: 25;
+    }
+
+    .overlayOpen {
+        opacity: 1;
+        pointer-events: auto;
+    }
+
+    .sidebar {
+        position: fixed;
+        top: 80px;
+        left: 0;
+        height: calc(100vh - 80px);
+        transform: translateX(-100%);
+        transition: transform 0.2s;
+        z-index: 30;
+        box-shadow: 4px 0 12px rgba(0, 0, 0, 0.1);
+    }
+
+    .sidebarOpen {
+        transform: translateX(0);
+    }
+
+    .sidebarClose {
+        display: block;
+        align-self: flex-end;
+        background: none;
+        border: none;
+        font-size: 1.75rem;
+        line-height: 1;
+        color: #374151;
+        cursor: pointer;
+        margin-bottom: 12px;
+    }
+
+    .pageContent {
+        padding: 20px;
+    }
 }

--- a/src/pages/EscolherPerfil/EscolherPerfil.module.css
+++ b/src/pages/EscolherPerfil/EscolherPerfil.module.css
@@ -62,3 +62,17 @@
 .profileButton:hover {
     background-color: #154c41;
 }
+
+@media (max-width: 640px) {
+    .header {
+        padding: 0 16px;
+    }
+
+    .content {
+        padding: 24px;
+    }
+
+    .title {
+        font-size: 1.5rem;
+    }
+}

--- a/src/pages/app/Dashboard/Dashboard.module.css
+++ b/src/pages/app/Dashboard/Dashboard.module.css
@@ -132,3 +132,19 @@
 .actionBtn:hover {
     background-color: rgba(0, 0, 0, 0.08);
 }
+
+@media (max-width: 1024px) {
+    .statsRow {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+@media (max-width: 560px) {
+    .statsRow {
+        grid-template-columns: 1fr;
+    }
+
+    .statValue {
+        font-size: 2.25rem;
+    }
+}

--- a/src/pages/app/ListagemItems/ListagemItems.module.css
+++ b/src/pages/app/ListagemItems/ListagemItems.module.css
@@ -179,3 +179,18 @@
     color: #ffffff;
     font-weight: 600;
   }
+
+  @media (max-width: 640px) {
+    .headerRow {
+      flex-wrap: wrap;
+      gap: 12px;
+    }
+
+    .filterRow {
+      flex-wrap: wrap;
+    }
+
+    .searchContainer {
+      width: 100%;
+    }
+  }

--- a/src/pages/app/ListagemPedidos/ListagemPedidos.module.css
+++ b/src/pages/app/ListagemPedidos/ListagemPedidos.module.css
@@ -166,3 +166,18 @@
     color: #ffffff;
     font-weight: 600;
 }
+
+@media (max-width: 640px) {
+    .headerRow {
+        flex-wrap: wrap;
+        gap: 12px;
+    }
+
+    .filterRow {
+        flex-wrap: wrap;
+    }
+
+    .searchContainer {
+        width: 100%;
+    }
+}

--- a/src/pages/app/ListagemUsuarios/ListagemUsuarios.module.css
+++ b/src/pages/app/ListagemUsuarios/ListagemUsuarios.module.css
@@ -166,3 +166,18 @@
     color: #ffffff;
     font-weight: 600;
 }
+
+@media (max-width: 640px) {
+    .headerRow {
+        flex-wrap: wrap;
+        gap: 12px;
+    }
+
+    .filterRow {
+        flex-wrap: wrap;
+    }
+
+    .searchContainer {
+        width: 100%;
+    }
+}

--- a/src/pages/app/PaginaUsuario/PaginaUsuario.module.css
+++ b/src/pages/app/PaginaUsuario/PaginaUsuario.module.css
@@ -194,3 +194,24 @@
 .saveButton:hover {
     background-color: #157347;
 }
+
+@media (max-width: 640px) {
+    .card {
+        padding: 20px;
+    }
+
+    .formContent {
+        grid-template-columns: 1fr;
+        gap: 24px;
+    }
+
+    .imagePlaceholder {
+        height: 180px;
+    }
+
+    .actionsFooter {
+        flex-direction: column-reverse;
+        gap: 12px;
+        align-items: stretch;
+    }
+}


### PR DESCRIPTION
## Summary
Nenhum dos 12 arquivos CSS da área logada tinha media query (o Figma dessas telas foi desenhado só pra desktop). Achados e correções:

- **AppLayout e UserLayout**: a sidebar (280px/283px fixos) agora colapsa atrás de um botão hambúrguer abaixo de 900px, com overlay escuro e botão de fechar, mesmo padrão do menu mobile do site institucional (#22). Nome/role do usuário no header somem em telas pequenas, sobra só o avatar, pra caber o botão de menu + logo.
- **Dashboard**: grid de cards de resumo, 4 colunas em desktop, 2 em tablet (≤1024px), 1 em celular (≤560px), com fonte do número reduzida no menor breakpoint.
- **ListagemItems/ListagemPedidos/ListagemUsuarios**: `headerRow` e `filterRow` ganham `flex-wrap`, campo de busca vira 100% de largura abaixo de 640px (antes fixo em 320px).
- **PaginaUsuario**: o grid de 2 colunas do formulário (foto + campos) vira 1 coluna abaixo de 640px, botões do rodapé empilham.
- **EscolherPerfil**: padding reduzido e título menor em telas pequenas.

Não mexi em `PedidoAguardandoAprovacao`/`Conclusao` nem em `MinhasSolicitacoes`, ambos já usavam `flex-wrap`/grid `auto-fill` e se adaptam sem precisar de media query própria. As tabelas (Items/Pedidos/Usuários) já tinham `overflow-x: auto`, então não foram alteradas.

Conferência visual fica coberta pelas issues de QA #80, #81, #82, #83 e #84 (todas já atualizadas com os itens específicos de responsividade dessa PR).

Closes #87

## Test plan
- [x] `npm run lint` sem erros
- [x] `npm run build` sem erros