### PR TITLE
fix: menu do site quebrando em larguras intermediárias (768-1024px)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -819,31 +819,6 @@ footer {
 }
 
 @media (max-width: 1024px) {
-    #hero-section>div:last-child {
-        display: none;
-    }
-
-    .catalog-intro {
-        display: flex;
-        flex-direction: column;
-    }
-
-    #catalog-filters,
-    .select-custom,
-    #catalog-filters button,
-    .catalog-filters__field {
-        width: 100%;
-    }
-
-    .catalog-intro p {
-        max-width: none;
-    }
-
-}
-
-/* MOBILE */
-@media (max-width: 768px) {
-
     .menu__list,
     .menu__actions {
         display: none;
@@ -919,6 +894,31 @@ footer {
         opacity: 1;
         visibility: visible;
     }
+
+    #hero-section>div:last-child {
+        display: none;
+    }
+
+    .catalog-intro {
+        display: flex;
+        flex-direction: column;
+    }
+
+    #catalog-filters,
+    .select-custom,
+    #catalog-filters button,
+    .catalog-filters__field {
+        width: 100%;
+    }
+
+    .catalog-intro p {
+        max-width: none;
+    }
+
+}
+
+/* MOBILE */
+@media (max-width: 768px) {
 
     /* HOME */
     .stats-section__list {


### PR DESCRIPTION
## Summary
O menu desktop (logo + 5 links + botões Entrar/Cadastre-se) precisa de mais espaço horizontal do que 768px pra caber sem sobrepor. O menu mobile (hambúrguer) só assumia abaixo de 768px, então existia uma faixa de largura (~768px a ~1024px, típica de notebook ou janela não maximizada) onde nem o desktop nem o mobile funcionavam direito: texto do logo sobrepondo o primeiro link, botão "Cadastre-se" quebrando em duas linhas e vazando pra fora da tela.

Move a troca pro menu mobile de 768px pra 1024px (breakpoint que já existia no arquivo, usado por outras regras), cobrindo a faixa antes quebrada. As regras de conteúdo que ainda fazem sentido só abaixo de 768px (Home, Sobre, Como Participar, Catálogo, Footer) continuam lá, só as regras do menu em si foram movidas.

Encontrado numa captura de tela do usuário mostrando o menu sobreposto numa largura intermediária. Esse bug já existia no site original desde antes da migração (`#15`), não foi introduzido pela `#87`.

Conferência visual fica coberta pela issue de QA #79 (já atualizada com o item específico dessa faixa de largura).

Closes #89

## Test plan
- [x] `npm run lint` sem erros
- [x] `npm run build` sem erros (CSS resultante com o mesmo tamanho, só reorganizado)
- [x] Chaves CSS balanceadas conferidas manualmente (141 aberturas / 141 fechamentos)