### PR TITLE
fix: adicionar .env ao gitignore e documentar setup de variáveis de ambiente

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.env
 
 # Editor directories and files
 .vscode/*

--- a/README.md
+++ b/README.md
@@ -220,6 +220,18 @@ Para visualizar o MVP:
 2. Navegue pelas telas interativas;
 3. Teste os fluxos principais da aplicação.
 
+### Variáveis de ambiente (execução local)
+
+Antes de rodar `npm run dev`, copie o arquivo de exemplo e ajuste se necessário:
+
+```bash
+cp .env.example .env
+```
+
+A variável `VITE_API_URL` deve apontar para o back-end (NestJS) rodando localmente, por padrão `http://localhost:3000`. Sem esse arquivo, as chamadas à API não funcionam.
+
+> O passo a passo completo de instalação e execução (dependências, banco de dados, back-end) será detalhado na íntegra em breve.
+
 ## 📋 Critérios de Desenvolvimento Atendidos
 
 ✔ Protótipo de alta fidelidade


### PR DESCRIPTION
## O que mudou

- Adicionado `.env` ao `.gitignore` (antes só `*.local` era ignorado, então o `.env` corria risco de ser commitado sem querer).
- Adicionada uma nota curta na seção "Como executar ou utilizar a aplicação" do README explicando que é preciso copiar `.env.example` para `.env` (com `VITE_API_URL`) antes de rodar `npm run dev`.

## Por quê

Sem `.env` local, o axios (`src/services/api.js`) monta as chamadas sem `baseURL`, então as requisições caem no próprio servidor do Vite em vez do back-end NestJS. Isso deixava rotas como `/app/dashboard` em branco, sem nenhum erro óbvio no fluxo.

A reescrita completa da seção de instalação/execução do README (hoje ainda descreve só a fase de prototipação no Figma) fica para a #27.

Closes #91

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [x] Reproduzido o problema localmente (sem `.env`, `/app/dashboard` fica em branco) e confirmado que copiar `.env.example` para `.env` + reiniciar o Vite resolve