### PR TITLE
feat: mecanismo de usuário atual no front sem login real

### DIFF
--- a/src/pages/EscolherPerfil/EscolherPerfil.jsx
+++ b/src/pages/EscolherPerfil/EscolherPerfil.jsx
@@ -1,9 +1,20 @@
 import { Link, useNavigate } from 'react-router-dom';
 import styles from './EscolherPerfil.module.css';
 import logoImgSrc from '../../assets/logo-full.png';
+import { DEMO_USER_IDS, setCurrentUserId } from '../../services/currentUser.js';
 
 export default function EscolherPerfil() {
     const navigate = useNavigate();
+
+    const handleEscolherComum = () => {
+        setCurrentUserId(DEMO_USER_IDS.COMUM);
+        navigate('/user/minhas-solicitacoes');
+    };
+
+    const handleEscolherAdmin = () => {
+        setCurrentUserId(DEMO_USER_IDS.ADMIN);
+        navigate('/app/dashboard');
+    };
 
     return (
         <div className={styles.container}>
@@ -20,14 +31,14 @@ export default function EscolherPerfil() {
                     <button
                         type="button"
                         className={styles.profileButton}
-                        onClick={() => navigate('/user/minhas-solicitacoes')}
+                        onClick={handleEscolherComum}
                     >
                         Usuário comum
                     </button>
                     <button
                         type="button"
                         className={styles.profileButton}
-                        onClick={() => navigate('/app/dashboard')}
+                        onClick={handleEscolherAdmin}
                     >
                         Usuário admin
                     </button>

--- a/src/services/currentUser.js
+++ b/src/services/currentUser.js
@@ -1,0 +1,19 @@
+const STORAGE_KEY = 'passaadiante:currentUserId';
+
+/**
+ * IDs fixos dos usuários de demonstração criados pelo seed do back
+ * (PassaAdiante-NestJS, prisma/seed.ts). Não há login/autenticação real no MVP:
+ * cada perfil escolhido em /escolher-perfil é associado a um desses usuários.
+ */
+export const DEMO_USER_IDS = {
+    COMUM: '00000000-0000-0000-0000-000000000001',
+    ADMIN: '00000000-0000-0000-0000-000000000002',
+};
+
+export function setCurrentUserId(userId) {
+    localStorage.setItem(STORAGE_KEY, userId);
+}
+
+export function getCurrentUserId() {
+    return localStorage.getItem(STORAGE_KEY);
+}


### PR DESCRIPTION
## O que mudou

- `src/services/currentUser.js`: constantes `DEMO_USER_IDS` com os IDs fixos dos dois usuários de demonstração criados pelo seed do back (Matheus-Rodrigues-EC/PassaAdiante-NestJS#18), e um helper simples `setCurrentUserId`/`getCurrentUserId` que lê/grava no `localStorage` (chave `passaadiante:currentUserId`)
- `EscolherPerfil.jsx`: ao clicar em "Usuário comum" ou "Usuário admin", grava o id do usuário correspondente antes de navegar

## Por quê

Não há login/autenticação real no MVP. Essa é a base pra telas como Minhas Solicitações (`#94`) saberem de quem são os dados a filtrar.

Sem context/provider React por enquanto, um helper de leitura direta do `localStorage` é suficiente pro escopo do MVP.

Depende de Matheus-Rodrigues-EC/PassaAdiante-NestJS#18 (ainda não mergeada, mas os IDs fixos usados aqui já estão definidos e não devem mudar)

Closes #93

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [x] Atualizada a issue de QA #84 com um item de checklist pra conferir a gravação no localStorage