### PR TITLE
feat: integrar Minhas Solicitações com a API do NestJS

### DIFF
--- a/src/pages/user/MinhasSolicitacoes/MinhasSolicitacoes.jsx
+++ b/src/pages/user/MinhasSolicitacoes/MinhasSolicitacoes.jsx
@@ -1,22 +1,54 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import styles from './MinhasSolicitacoes.module.css';
+import { listOrders, updateOrderStatus } from '../../../services/ordersService.js';
+import { getCurrentUserId } from '../../../services/currentUser.js';
+import { statusOptions, statusLabel } from '../../../data/orderOptions.js';
 
-const STATUS_OPTIONS = ['TODAS', 'PENDENTE', 'APROVADO', 'RECUSADO', 'CONCLUÍDO'];
-
-const mockSolicitacoes = [
-    { id: 1, item: 'Kit de Livros Didáticos - 5° Ano (Ensino Fundamental)', doador: 'M. Oliveira', status: 'PENDENTE' },
-    { id: 2, item: 'Mochila Escolar Reforçada', doador: 'R. Bezerra', status: 'APROVADO' },
-    { id: 3, item: 'Coleção de Livros Didáticos', doador: 'S. Ferreira', status: 'RECUSADO' },
-    { id: 4, item: 'Kit de Lápis de Cor 48un.', doador: 'A. Beatriz', status: 'CONCLUÍDO' },
-    { id: 5, item: 'Estojo Escolar', doador: 'L. Martins', status: 'PENDENTE' },
-];
+const STATUS_FILTER_OPTIONS = [{ value: 'TODAS', label: 'Todas' }, ...statusOptions];
 
 export default function MinhasSolicitacoes() {
+    const [solicitacoes, setSolicitacoes] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+    const [savingId, setSavingId] = useState(null);
     const [searchTerm, setSearchTerm] = useState('');
     const [statusFilter, setStatusFilter] = useState('TODAS');
 
-    const filteredSolicitacoes = mockSolicitacoes.filter((solicitacao) => {
-        const matchesSearch = solicitacao.item.toLowerCase().includes(searchTerm.toLowerCase());
+    function fetchSolicitacoes() {
+        const currentUserId = getCurrentUserId();
+
+        return listOrders().then((orders) => {
+            setSolicitacoes(orders.filter((order) => order.userId === currentUserId));
+        });
+    }
+
+    useEffect(() => {
+        let cancelled = false;
+
+        fetchSolicitacoes()
+            .catch(() => {
+                if (!cancelled) setError('Não foi possível carregar suas solicitações.');
+            })
+            .finally(() => {
+                if (!cancelled) setLoading(false);
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    function handleUpdateStatus(orderId, newStatus) {
+        setSavingId(orderId);
+        setError(null);
+        updateOrderStatus(orderId, newStatus)
+            .then(() => fetchSolicitacoes())
+            .catch(() => setError('Não foi possível atualizar a solicitação.'))
+            .finally(() => setSavingId(null));
+    }
+
+    const filteredSolicitacoes = solicitacoes.filter((solicitacao) => {
+        const matchesSearch = solicitacao.item.name.toLowerCase().includes(searchTerm.toLowerCase());
         const matchesStatus = statusFilter === 'TODAS' || solicitacao.status === statusFilter;
         return matchesSearch && matchesStatus;
     });
@@ -24,6 +56,8 @@ export default function MinhasSolicitacoes() {
     return (
         <div className={styles.pageContainer}>
             <h1 className={styles.pageTitle}>Minhas Solicitações</h1>
+
+            {error && <p className={styles.errorMessage}>{error}</p>}
 
             <div className={styles.filtersRow}>
                 <input
@@ -42,35 +76,47 @@ export default function MinhasSolicitacoes() {
                         onChange={(event) => setStatusFilter(event.target.value)}
                         className={styles.statusSelect}
                     >
-                        {STATUS_OPTIONS.map((option) => (
-                            <option key={option} value={option}>{option}</option>
+                        {STATUS_FILTER_OPTIONS.map((option) => (
+                            <option key={option.value} value={option.value}>{option.label}</option>
                         ))}
                     </select>
                 </div>
             </div>
 
-            {filteredSolicitacoes.length > 0 ? (
+            {loading ? (
+                <p className={styles.emptyState}>Carregando...</p>
+            ) : filteredSolicitacoes.length > 0 ? (
                 <div className={styles.grid}>
                     {filteredSolicitacoes.map((solicitacao) => (
                         <article key={solicitacao.id} className={styles.card}>
                             <div className={styles.cardImage} />
                             <div className={styles.cardContent}>
-                                <h2 className={styles.cardTitle}>{solicitacao.item}</h2>
+                                <h2 className={styles.cardTitle}>{solicitacao.item.name}</h2>
                                 <p className={styles.cardDonor}>
-                                    <strong>Doador:</strong> {solicitacao.doador}
+                                    <strong>Doador:</strong> {solicitacao.item.user?.name ?? '—'}
                                 </p>
 
-                                <span className={`${styles.badge} ${styles[`badge${solicitacao.status.replace('Í', 'I')}`]}`}>
-                                    {solicitacao.status}
+                                <span className={`${styles.badge} ${styles[`badge${solicitacao.status}`]}`}>
+                                    {statusLabel(solicitacao.status)}
                                 </span>
 
-                                {solicitacao.status === 'PENDENTE' && (
-                                    <button type="button" className={styles.cancelButton}>
+                                {solicitacao.status === 'PENDING' && (
+                                    <button
+                                        type="button"
+                                        className={styles.cancelButton}
+                                        onClick={() => handleUpdateStatus(solicitacao.id, 'CANCELED')}
+                                        disabled={savingId === solicitacao.id}
+                                    >
                                         Cancelar Pedido
                                     </button>
                                 )}
-                                {solicitacao.status === 'APROVADO' && (
-                                    <button type="button" className={styles.confirmButton}>
+                                {solicitacao.status === 'APPROVED' && (
+                                    <button
+                                        type="button"
+                                        className={styles.confirmButton}
+                                        onClick={() => handleUpdateStatus(solicitacao.id, 'COMPLETED')}
+                                        disabled={savingId === solicitacao.id}
+                                    >
                                         Confirmar Entrega
                                     </button>
                                 )}

--- a/src/pages/user/MinhasSolicitacoes/MinhasSolicitacoes.module.css
+++ b/src/pages/user/MinhasSolicitacoes/MinhasSolicitacoes.module.css
@@ -12,6 +12,16 @@
     margin: 0;
 }
 
+.errorMessage {
+    background-color: #fef2f2;
+    color: #b91c1c;
+    border: 1px solid #fecaca;
+    border-radius: 8px;
+    padding: 12px 16px;
+    font-size: 0.9rem;
+    margin: 0;
+}
+
 .filtersRow {
     display: flex;
     align-items: flex-end;
@@ -110,19 +120,19 @@
     color: #ffffff;
 }
 
-.badgePENDENTE {
+.badgePENDING {
     background-color: #fa0;
 }
 
-.badgeAPROVADO {
+.badgeAPPROVED {
     background-color: #43b75d;
 }
 
-.badgeRECUSADO {
+.badgeCANCELED {
     background-color: #ee443f;
 }
 
-.badgeCONCLUIDO {
+.badgeCOMPLETED {
     background-color: #078c5b;
 }
 
@@ -156,6 +166,12 @@
 
 .confirmButton:hover {
     background-color: rgba(67, 183, 93, 0.08);
+}
+
+.cancelButton:disabled,
+.confirmButton:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
 }
 
 .emptyState {


### PR DESCRIPTION
## O que mudou

- `MinhasSolicitacoes.jsx`: troca `mockSolicitacoes` por `listOrders()`, filtrando no front os pedidos cujo `userId` é o do usuário comum de demonstração (`getCurrentUserId()`, da #93)
- Filtro de status adaptado pro enum real (`PENDING`/`APPROVED`/`COMPLETED`/`CANCELED`), usando `statusLabel()` de `src/data/orderOptions.js`
- Card mostra `item.name` e o doador real (`item.user.name`)
- "Cancelar Pedido" (status Pendente) chama `updateOrderStatus(id, 'CANCELED')`; "Confirmar Entrega" (status Aprovado) chama `updateOrderStatus(id, 'COMPLETED')`; nenhuma ação pra Concluído/Cancelado — mesmo comportamento condicional que já existia no mock, só ligado à API de verdade
- Loading e tratamento de erro na busca e nas ações, seguindo o padrão das telas do Admin
- Classes de badge renomeadas de português (`badgePENDENTE` etc.) pro enum real (`badgePENDING` etc.)

## Por quê

Fecha a integração do único fluxo funcional do perfil Usuário comum, tirando o último dado mockado do app (fora as telas placeholder Minhas Doações/Catálogo, que ficam pras #95/#96).

Depende de #93 (mecanismo de usuário atual) e de Matheus-Rodrigues-EC/PassaAdiante-NestJS#19 (o back precisou de um fix pra incluir o doador na resposta de pedidos)

Closes #94

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [x] Testado de ponta a ponta contra uma instância local do back rodando a branch do #19 (porta 3001, banco de teste): criei pedidos de teste pro usuário comum de demonstração, confirmei que só eles aparecem na listagem, com o nome do doador correto, e que os botões "Cancelar Pedido"/"Confirmar Entrega" mudam o status de verdade (`PENDING`→`CANCELED`, `APPROVED`→`COMPLETED`)
- [x] Atualizada a issue de QA #84 com os itens de checklist correspondentes