### PR TITLE
feat: tela de Catálogo (usuário comum) com dados mockados

### DIFF
--- a/src/pages/user/Catalogo/Catalogo.jsx
+++ b/src/pages/user/Catalogo/Catalogo.jsx
@@ -1,0 +1,99 @@
+import { useState } from 'react';
+import styles from './Catalogo.module.css';
+import { categoryOptions, categoryLabel, conditionLabel } from '../../../data/itemOptions.js';
+
+const CATEGORY_FILTER_OPTIONS = [{ value: 'TODOS', label: 'Todas' }, ...categoryOptions];
+
+const mockCatalogo = [
+    { id: 1, item: 'Kit de Livros Didáticos - 5° Ano (Ensino Fundamental)', doador: 'Ana Souza', localizacao: 'Bairro XX, Caucaia-CE', category: 'BOOK', condition: 'GOOD' },
+    { id: 2, item: 'Mochila Escolar Reforçada', doador: 'Carlos Lima', localizacao: 'Bairro YY, Caucaia-CE', category: 'BACKPACK', condition: 'NEW' },
+    { id: 3, item: 'Kit de Lápis de Cor 48un.', doador: 'Fernanda Alves', localizacao: 'Bairro ZZ, Caucaia-CE', category: 'PENCIL', condition: 'NEW' },
+    { id: 4, item: 'Uniforme Escolar Tamanho M', doador: 'João Pedro', localizacao: 'Bairro XX, Caucaia-CE', category: 'UNIFORM', condition: 'GOOD' },
+    { id: 5, item: 'Estojo Escolar', doador: 'Marina Costa', localizacao: 'Bairro YY, Caucaia-CE', category: 'PENCIL_CASE', condition: 'FAIR' },
+    { id: 6, item: 'Caderno Universitário 200 folhas', doador: 'Ana Souza', localizacao: 'Bairro XX, Caucaia-CE', category: 'NOTEBOOK', condition: 'NEW' },
+];
+
+export default function Catalogo() {
+    const [searchTerm, setSearchTerm] = useState('');
+    const [categoryFilter, setCategoryFilter] = useState('TODOS');
+    const [requestedIds, setRequestedIds] = useState([]);
+
+    const filteredCatalogo = mockCatalogo.filter((item) => {
+        const matchesSearch = item.item.toLowerCase().includes(searchTerm.toLowerCase());
+        const matchesCategory = categoryFilter === 'TODOS' || item.category === categoryFilter;
+        return matchesSearch && matchesCategory;
+    });
+
+    function handleSolicitar(itemId) {
+        setRequestedIds((current) => [...current, itemId]);
+    }
+
+    return (
+        <div className={styles.pageContainer}>
+            <h1 className={styles.pageTitle}>Catálogo</h1>
+
+            <div className={styles.filtersRow}>
+                <input
+                    type="text"
+                    placeholder="Buscar por nome do item"
+                    value={searchTerm}
+                    onChange={(event) => setSearchTerm(event.target.value)}
+                    className={styles.searchInput}
+                />
+
+                <div className={styles.statusField}>
+                    <label htmlFor="category-filter">Categoria</label>
+                    <select
+                        id="category-filter"
+                        value={categoryFilter}
+                        onChange={(event) => setCategoryFilter(event.target.value)}
+                        className={styles.statusSelect}
+                    >
+                        {CATEGORY_FILTER_OPTIONS.map((option) => (
+                            <option key={option.value} value={option.value}>{option.label}</option>
+                        ))}
+                    </select>
+                </div>
+            </div>
+
+            {filteredCatalogo.length > 0 ? (
+                <div className={styles.grid}>
+                    {filteredCatalogo.map((item) => {
+                        const jaSolicitado = requestedIds.includes(item.id);
+
+                        return (
+                            <article key={item.id} className={styles.card}>
+                                <div className={styles.cardImage} />
+                                <div className={styles.cardContent}>
+                                    <h2 className={styles.cardTitle}>{item.item}</h2>
+                                    <p className={styles.cardDonor}>
+                                        <strong>Doador:</strong> {item.doador}
+                                    </p>
+                                    <p className={styles.cardLocation}>
+                                        <strong>Localização:</strong> {item.localizacao}
+                                    </p>
+
+                                    <div className={styles.badgeRow}>
+                                        <span className={styles.badge}>{categoryLabel(item.category)}</span>
+                                        <span className={styles.badge}>{conditionLabel(item.condition)}</span>
+                                    </div>
+
+                                    <button
+                                        type="button"
+                                        className={styles.primaryButton}
+                                        onClick={() => handleSolicitar(item.id)}
+                                        disabled={jaSolicitado}
+                                    >
+                                        {jaSolicitado ? 'Solicitado' : 'Solicitar Item'}
+                                    </button>
+                                </div>
+                            </article>
+                        );
+                    })}
+                </div>
+            ) : (
+                <p className={styles.emptyState}>Nenhum item encontrado.</p>
+            )}
+        </div>
+    );
+}

--- a/src/pages/user/Catalogo/Catalogo.module.css
+++ b/src/pages/user/Catalogo/Catalogo.module.css
@@ -1,0 +1,151 @@
+.pageContainer {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    width: 100%;
+}
+
+.pageTitle {
+    font-size: 1.5rem;
+    font-weight: bold;
+    color: #111827;
+    margin: 0;
+}
+
+.filtersRow {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 24px;
+    flex-wrap: wrap;
+}
+
+.searchInput {
+    flex: 1;
+    min-width: 260px;
+    padding: 12px 16px;
+    border: 1.5px solid #e5e7ea;
+    border-radius: 12px;
+    background-color: #f9fafb;
+    font-size: 1rem;
+    outline: none;
+}
+
+.searchInput:focus {
+    border-color: #1e6b5c;
+    background-color: #ffffff;
+}
+
+.statusField {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.statusField label {
+    font-size: 0.95rem;
+    font-weight: 500;
+    color: #131927;
+}
+
+.statusSelect {
+    min-width: 200px;
+    padding: 12px 16px;
+    border: 1.5px solid #e5e7ea;
+    border-radius: 12px;
+    background-color: #f9fafb;
+    font-size: 1rem;
+    outline: none;
+}
+
+.grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: 24px;
+}
+
+.card {
+    background-color: #ffffff;
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 4px 10px -4px rgba(19, 25, 39, 0.12), 0 7px 23px -3px rgba(19, 25, 39, 0.1);
+    display: flex;
+    flex-direction: column;
+}
+
+.cardImage {
+    background-color: #d9d9d9;
+    aspect-ratio: 16 / 10;
+    width: 100%;
+}
+
+.cardContent {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 16px;
+}
+
+.cardTitle {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: #131927;
+    margin: 0;
+}
+
+.cardDonor {
+    font-size: 0.85rem;
+    color: #6d717f;
+    margin: 0;
+}
+
+.cardLocation {
+    font-size: 0.85rem;
+    color: #6d717f;
+    margin: 0;
+}
+
+.badgeRow {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 3px 10px;
+    border-radius: 5px;
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: #ffffff;
+    background-color: #0568a6;
+}
+
+.primaryButton {
+    width: 100%;
+    padding: 10px 14px;
+    background-color: #0568a6;
+    border: none;
+    border-radius: 8px;
+    color: #ffffff;
+    font-weight: 600;
+    font-size: 0.85rem;
+    cursor: pointer;
+}
+
+.primaryButton:hover:not(:disabled) {
+    background-color: #045181;
+}
+
+.primaryButton:disabled {
+    background-color: #9ca3af;
+    cursor: default;
+}
+
+.emptyState {
+    text-align: center;
+    color: #6d717f;
+    padding: 40px 0;
+}

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -19,6 +19,7 @@ import EscolherPerfil from './pages/EscolherPerfil/EscolherPerfil.jsx'
 import { UserLayout } from './layouts/UserLayout.jsx'
 import MinhasSolicitacoes from './pages/user/MinhasSolicitacoes/MinhasSolicitacoes.jsx'
 import MinhasDoacoes from './pages/user/MinhasDoacoes/MinhasDoacoes.jsx'
+import UserCatalogo from './pages/user/Catalogo/Catalogo.jsx'
 
 function AppRoutes() {
   return (
@@ -47,7 +48,7 @@ function AppRoutes() {
       <Route path="/user" element={<UserLayout />}>
         <Route path="minhas-solicitacoes" element={<MinhasSolicitacoes />} />
         <Route path="minhas-doacoes" element={<MinhasDoacoes />} />
-        <Route path="catalogo" element={<h1>Catálogo</h1>} />
+        <Route path="catalogo" element={<UserCatalogo />} />
       </Route>
     </Routes>
   )


### PR DESCRIPTION
## Summary
- Substitui o placeholder de `/user/catalogo` pela tela real (`src/pages/user/Catalogo/`)
- Grid de itens mockados com busca por nome, filtro por categoria e ação de solicitar (mockada, integração com a API fica para issue futura)
- Segue o mesmo padrão visual de Minhas Doações/Solicitações (#35, #99)

## Test plan
- [x] `npm run dev` e navegação manual: `/escolher-perfil` → Usuário comum → sidebar Catálogo
- [x] Busca por nome filtra a grid
- [x] Filtro por categoria filtra a grid
- [x] Botão "Solicitar Item" muda para "Solicitado" e desabilita
- [x] Sem erros no console

Closes #96