### PR TITLE
feat: integrar Minhas Doações com a API do NestJS

### DIFF
--- a/src/pages/user/EditarDoacao/EditarDoacao.jsx
+++ b/src/pages/user/EditarDoacao/EditarDoacao.jsx
@@ -1,0 +1,154 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import styles from './EditarDoacao.module.css';
+import { categoryOptions, conditionOptions, availabilityOptions } from '../../../data/itemOptions.js';
+import { getItem, updateItem } from '../../../services/itemsService.js';
+
+const emptyForm = {
+    name: '',
+    description: '',
+    category: categoryOptions[0].value,
+    condition: conditionOptions[0].value,
+    availability: availabilityOptions[0].value,
+};
+
+export default function EditarDoacao() {
+    const navigate = useNavigate();
+    const { id } = useParams();
+
+    const [form, setForm] = useState(emptyForm);
+    const [loading, setLoading] = useState(true);
+    const [saving, setSaving] = useState(false);
+    const [error, setError] = useState(null);
+
+    useEffect(() => {
+        let cancelled = false;
+
+        getItem(id)
+            .then((data) => {
+                if (!cancelled) {
+                    setForm({
+                        name: data.name,
+                        description: data.description ?? '',
+                        category: data.category,
+                        condition: data.condition,
+                        availability: data.availability,
+                    });
+                }
+            })
+            .catch(() => {
+                if (!cancelled) setError('Não foi possível carregar o item.');
+            })
+            .finally(() => {
+                if (!cancelled) setLoading(false);
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [id]);
+
+    function handleChange(field, value) {
+        setForm((current) => ({ ...current, [field]: value }));
+    }
+
+    function handleSubmit(event) {
+        event.preventDefault();
+        setSaving(true);
+        setError(null);
+
+        updateItem(id, { ...form, description: form.description || undefined })
+            .then(() => navigate('/user/minhas-doacoes'))
+            .catch(() => {
+                setError('Não foi possível salvar as alterações. Confira os campos e tente novamente.');
+                setSaving(false);
+            });
+    }
+
+    if (loading) {
+        return (
+            <div className={styles.pageContainer}>
+                <p>Carregando...</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className={styles.pageContainer}>
+            <h2 className={styles.pageTitle}>Editar item</h2>
+
+            {error && <p className={styles.errorMessage}>{error}</p>}
+
+            <form className={styles.card} onSubmit={handleSubmit}>
+                <div className={styles.field}>
+                    <label htmlFor="item-nome">Nome do item:</label>
+                    <input
+                        id="item-nome"
+                        type="text"
+                        value={form.name}
+                        onChange={(event) => handleChange('name', event.target.value)}
+                        required
+                    />
+                </div>
+
+                <div className={styles.field}>
+                    <label htmlFor="item-descricao">Descrição:</label>
+                    <input
+                        id="item-descricao"
+                        type="text"
+                        value={form.description}
+                        onChange={(event) => handleChange('description', event.target.value)}
+                    />
+                </div>
+
+                <div className={styles.field}>
+                    <label htmlFor="item-categoria">Categoria:</label>
+                    <select
+                        id="item-categoria"
+                        value={form.category}
+                        onChange={(event) => handleChange('category', event.target.value)}
+                    >
+                        {categoryOptions.map((option) => (
+                            <option key={option.value} value={option.value}>{option.label}</option>
+                        ))}
+                    </select>
+                </div>
+
+                <div className={styles.field}>
+                    <label htmlFor="item-estado">Estado de conservação:</label>
+                    <select
+                        id="item-estado"
+                        value={form.condition}
+                        onChange={(event) => handleChange('condition', event.target.value)}
+                    >
+                        {conditionOptions.map((option) => (
+                            <option key={option.value} value={option.value}>{option.label}</option>
+                        ))}
+                    </select>
+                </div>
+
+                <div className={styles.field}>
+                    <label htmlFor="item-disponivel">Disponibilidade:</label>
+                    <select
+                        id="item-disponivel"
+                        value={form.availability}
+                        onChange={(event) => handleChange('availability', event.target.value)}
+                    >
+                        {availabilityOptions.map((option) => (
+                            <option key={option.value} value={option.value}>{option.label}</option>
+                        ))}
+                    </select>
+                </div>
+
+                <div className={styles.actions}>
+                    <button type="button" className={styles.cancelButton} onClick={() => navigate('/user/minhas-doacoes')}>
+                        Cancelar
+                    </button>
+                    <button type="submit" className={styles.saveButton} disabled={saving}>
+                        {saving ? 'Salvando...' : 'Salvar alterações'}
+                    </button>
+                </div>
+            </form>
+        </div>
+    );
+}

--- a/src/pages/user/EditarDoacao/EditarDoacao.module.css
+++ b/src/pages/user/EditarDoacao/EditarDoacao.module.css
@@ -1,0 +1,100 @@
+.pageContainer {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    width: 100%;
+    max-width: 640px;
+}
+
+.pageTitle {
+    font-size: 1.5rem;
+    font-weight: bold;
+    color: #111827;
+    margin: 0;
+}
+
+.errorMessage {
+    background-color: #fef2f2;
+    color: #b91c1c;
+    border: 1px solid #fecaca;
+    border-radius: 8px;
+    padding: 12px 16px;
+    font-size: 0.9rem;
+    margin: 0;
+}
+
+.card {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    background-color: #ffffff;
+    border-radius: 12px;
+    border: 1px solid #e5e7eb;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+    padding: 24px;
+}
+
+.field {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.field label {
+    font-weight: 700;
+    font-size: 1rem;
+    color: #111827;
+}
+
+.field input,
+.field select {
+    height: 48px;
+    padding: 0 16px;
+    border: 1px solid #ccd5dc;
+    border-radius: 10px;
+    font-size: 1rem;
+    background-color: #ffffff;
+    color: #111827;
+}
+
+.field input:focus,
+.field select:focus {
+    outline: none;
+    border-color: #0d6efd;
+}
+
+.actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+    margin-top: 8px;
+}
+
+.cancelButton {
+    background: none;
+    border: 1px solid #ccd5dc;
+    color: #374151;
+    padding: 10px 20px;
+    border-radius: 8px;
+    font-weight: 500;
+    cursor: pointer;
+}
+
+.cancelButton:hover {
+    background-color: #f3f4f6;
+}
+
+.saveButton {
+    background-color: #0d6efd;
+    color: #ffffff;
+    border: none;
+    padding: 10px 20px;
+    border-radius: 8px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.saveButton:hover {
+    background-color: #0b5ed7;
+}

--- a/src/pages/user/MinhasDoacoes/MinhasDoacoes.jsx
+++ b/src/pages/user/MinhasDoacoes/MinhasDoacoes.jsx
@@ -1,24 +1,58 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import styles from './MinhasDoacoes.module.css';
+import { listItems, deleteItem } from '../../../services/itemsService.js';
+import { getCurrentUserId } from '../../../services/currentUser.js';
 import { availabilityOptions, availabilityLabel } from '../../../data/itemOptions.js';
 
 const AVAILABILITY_FILTER_OPTIONS = [{ value: 'TODOS', label: 'Todos' }, ...availabilityOptions];
 
-const mockDoacoes = [
-    { id: 1, item: 'Kit de Livros Didáticos - 5° Ano (Ensino Fundamental)', localizacao: 'Bairro XX, Caucaia-CE', availability: 'AVAILABLE' },
-    { id: 2, item: 'Mochila Escolar Reforçada', localizacao: 'Bairro YY, Caucaia-CE', availability: 'AVAILABLE' },
-    { id: 3, item: 'Coleção de Livros Didáticos', localizacao: 'Bairro XX, Caucaia-CE', availability: 'DONATED' },
-    { id: 4, item: 'Kit de Lápis de Cor 48un.', localizacao: 'Bairro ZZ, Caucaia-CE', availability: 'AVAILABLE' },
-    { id: 5, item: 'Estojo Escolar', localizacao: 'Bairro YY, Caucaia-CE', availability: 'DONATED' },
-    { id: 6, item: 'Uniforme Escolar Tamanho M', localizacao: 'Bairro XX, Caucaia-CE', availability: 'AVAILABLE' },
-];
-
 export default function MinhasDoacoes() {
+    const navigate = useNavigate();
+    const [doacoes, setDoacoes] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+    const [deletingId, setDeletingId] = useState(null);
     const [searchTerm, setSearchTerm] = useState('');
     const [availabilityFilter, setAvailabilityFilter] = useState('TODOS');
 
-    const filteredDoacoes = mockDoacoes.filter((doacao) => {
-        const matchesSearch = doacao.item.toLowerCase().includes(searchTerm.toLowerCase());
+    function fetchDoacoes() {
+        const currentUserId = getCurrentUserId();
+
+        return listItems().then((items) => {
+            setDoacoes(items.filter((item) => item.userId === currentUserId));
+        });
+    }
+
+    useEffect(() => {
+        let cancelled = false;
+
+        fetchDoacoes()
+            .catch(() => {
+                if (!cancelled) setError('Não foi possível carregar suas doações.');
+            })
+            .finally(() => {
+                if (!cancelled) setLoading(false);
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    function handleExcluir(item) {
+        if (!window.confirm(`Excluir o item "${item.name}"? Essa ação não pode ser desfeita.`)) return;
+
+        setDeletingId(item.id);
+        setError(null);
+        deleteItem(item.id)
+            .then(() => fetchDoacoes())
+            .catch(() => setError('Não foi possível excluir o item.'))
+            .finally(() => setDeletingId(null));
+    }
+
+    const filteredDoacoes = doacoes.filter((doacao) => {
+        const matchesSearch = doacao.name.toLowerCase().includes(searchTerm.toLowerCase());
         const matchesAvailability = availabilityFilter === 'TODOS' || doacao.availability === availabilityFilter;
         return matchesSearch && matchesAvailability;
     });
@@ -26,6 +60,8 @@ export default function MinhasDoacoes() {
     return (
         <div className={styles.pageContainer}>
             <h1 className={styles.pageTitle}>Minhas Doações</h1>
+
+            {error && <p className={styles.errorMessage}>{error}</p>}
 
             <div className={styles.filtersRow}>
                 <input
@@ -51,30 +87,42 @@ export default function MinhasDoacoes() {
                 </div>
             </div>
 
-            {filteredDoacoes.length > 0 ? (
+            {loading ? (
+                <p className={styles.emptyState}>Carregando...</p>
+            ) : filteredDoacoes.length > 0 ? (
                 <div className={styles.grid}>
                     {filteredDoacoes.map((doacao) => (
                         <article key={doacao.id} className={styles.card}>
                             <div className={styles.cardImage} />
                             <div className={styles.cardContent}>
-                                <h2 className={styles.cardTitle}>{doacao.item}</h2>
-                                <p className={styles.cardLocation}>
-                                    <strong>Localização:</strong> {doacao.localizacao}
-                                </p>
+                                <h2 className={styles.cardTitle}>{doacao.name}</h2>
 
                                 <span className={`${styles.badge} ${styles[`badge${doacao.availability}`]}`}>
                                     {availabilityLabel(doacao.availability).toUpperCase()}
                                 </span>
 
-                                <button type="button" className={styles.primaryButton}>
+                                <button
+                                    type="button"
+                                    className={styles.primaryButton}
+                                    onClick={() => navigate(`/user/minhas-doacoes/${doacao.id}/solicitacoes`)}
+                                >
                                     Ver Solicitações
                                 </button>
 
                                 <div className={styles.secondaryActions}>
-                                    <button type="button" className={styles.editButton}>
+                                    <button
+                                        type="button"
+                                        className={styles.editButton}
+                                        onClick={() => navigate(`/user/minhas-doacoes/${doacao.id}/editar`)}
+                                    >
                                         Editar Item
                                     </button>
-                                    <button type="button" className={styles.deleteButton}>
+                                    <button
+                                        type="button"
+                                        className={styles.deleteButton}
+                                        onClick={() => handleExcluir(doacao)}
+                                        disabled={deletingId === doacao.id}
+                                    >
                                         Excluir Item
                                     </button>
                                 </div>

--- a/src/pages/user/SolicitacoesDoacao/SolicitacoesDoacao.jsx
+++ b/src/pages/user/SolicitacoesDoacao/SolicitacoesDoacao.jsx
@@ -1,0 +1,109 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import styles from './SolicitacoesDoacao.module.css';
+import { getItem } from '../../../services/itemsService.js';
+import { listOrders, updateOrderStatus } from '../../../services/ordersService.js';
+import { statusLabel } from '../../../data/orderOptions.js';
+
+export default function SolicitacoesDoacao() {
+    const navigate = useNavigate();
+    const { id } = useParams();
+
+    const [item, setItem] = useState(null);
+    const [solicitacoes, setSolicitacoes] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+    const [savingId, setSavingId] = useState(null);
+
+    function fetchSolicitacoes() {
+        return Promise.all([getItem(id), listOrders()]).then(([itemData, orders]) => {
+            setItem(itemData);
+            setSolicitacoes(orders.filter((order) => order.item.id === id));
+        });
+    }
+
+    useEffect(() => {
+        let cancelled = false;
+
+        fetchSolicitacoes()
+            .catch(() => {
+                if (!cancelled) setError('Não foi possível carregar as solicitações deste item.');
+            })
+            .finally(() => {
+                if (!cancelled) setLoading(false);
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [id]);
+
+    function handleUpdateStatus(orderId, newStatus) {
+        setSavingId(orderId);
+        setError(null);
+        updateOrderStatus(orderId, newStatus)
+            .then(() => fetchSolicitacoes())
+            .catch(() => setError('Não foi possível atualizar a solicitação.'))
+            .finally(() => setSavingId(null));
+    }
+
+    if (loading) {
+        return (
+            <div className={styles.pageContainer}>
+                <p>Carregando...</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className={styles.pageContainer}>
+            <button type="button" className={styles.backLink} onClick={() => navigate('/user/minhas-doacoes')}>
+                &larr; Voltar para Minhas Doações
+            </button>
+
+            <h1 className={styles.pageTitle}>Solicitações — {item?.name}</h1>
+
+            {error && <p className={styles.errorMessage}>{error}</p>}
+
+            {solicitacoes.length > 0 ? (
+                <div className={styles.grid}>
+                    {solicitacoes.map((solicitacao) => (
+                        <article key={solicitacao.id} className={styles.card}>
+                            <p className={styles.cardSolicitante}>
+                                <strong>Solicitante:</strong> {solicitacao.user.name}
+                            </p>
+                            <p className={styles.cardEmail}>{solicitacao.user.email}</p>
+
+                            <span className={`${styles.badge} ${styles[`badge${solicitacao.status}`]}`}>
+                                {statusLabel(solicitacao.status)}
+                            </span>
+
+                            {solicitacao.status === 'PENDING' && (
+                                <div className={styles.actions}>
+                                    <button
+                                        type="button"
+                                        className={styles.approveButton}
+                                        onClick={() => handleUpdateStatus(solicitacao.id, 'APPROVED')}
+                                        disabled={savingId === solicitacao.id}
+                                    >
+                                        Aprovar
+                                    </button>
+                                    <button
+                                        type="button"
+                                        className={styles.rejectButton}
+                                        onClick={() => handleUpdateStatus(solicitacao.id, 'CANCELED')}
+                                        disabled={savingId === solicitacao.id}
+                                    >
+                                        Recusar
+                                    </button>
+                                </div>
+                            )}
+                        </article>
+                    ))}
+                </div>
+            ) : (
+                <p className={styles.emptyState}>Nenhuma solicitação para este item ainda.</p>
+            )}
+        </div>
+    );
+}

--- a/src/pages/user/SolicitacoesDoacao/SolicitacoesDoacao.module.css
+++ b/src/pages/user/SolicitacoesDoacao/SolicitacoesDoacao.module.css
@@ -5,6 +5,21 @@
     width: 100%;
 }
 
+.backLink {
+    align-self: flex-start;
+    background: none;
+    border: none;
+    color: #0568a6;
+    font-weight: 600;
+    font-size: 0.9rem;
+    cursor: pointer;
+    padding: 0;
+}
+
+.backLink:hover {
+    text-decoration: underline;
+}
+
 .pageTitle {
     font-size: 1.5rem;
     font-weight: bold;
@@ -22,52 +37,6 @@
     margin: 0;
 }
 
-.filtersRow {
-    display: flex;
-    align-items: flex-end;
-    justify-content: space-between;
-    gap: 24px;
-    flex-wrap: wrap;
-}
-
-.searchInput {
-    flex: 1;
-    min-width: 260px;
-    padding: 12px 16px;
-    border: 1.5px solid #e5e7ea;
-    border-radius: 12px;
-    background-color: #f9fafb;
-    font-size: 1rem;
-    outline: none;
-}
-
-.searchInput:focus {
-    border-color: #1e6b5c;
-    background-color: #ffffff;
-}
-
-.statusField {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-}
-
-.statusField label {
-    font-size: 0.95rem;
-    font-weight: 500;
-    color: #131927;
-}
-
-.statusSelect {
-    min-width: 200px;
-    padding: 12px 16px;
-    border: 1.5px solid #e5e7ea;
-    border-radius: 12px;
-    background-color: #f9fafb;
-    font-size: 1rem;
-    outline: none;
-}
-
 .grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
@@ -77,19 +46,7 @@
 .card {
     background-color: #ffffff;
     border-radius: 12px;
-    overflow: hidden;
     box-shadow: 0 4px 10px -4px rgba(19, 25, 39, 0.12), 0 7px 23px -3px rgba(19, 25, 39, 0.1);
-    display: flex;
-    flex-direction: column;
-}
-
-.cardImage {
-    background-color: #d9d9d9;
-    aspect-ratio: 16 / 10;
-    width: 100%;
-}
-
-.cardContent {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
@@ -97,10 +54,16 @@
     padding: 16px;
 }
 
-.cardTitle {
+.cardSolicitante {
     font-size: 0.95rem;
     font-weight: 600;
     color: #131927;
+    margin: 0;
+}
+
+.cardEmail {
+    font-size: 0.85rem;
+    color: #6d717f;
     margin: 0;
 }
 
@@ -114,53 +77,45 @@
     color: #ffffff;
 }
 
-.badgeAVAILABLE {
+.badgePENDING {
+    background-color: #fa0;
+}
+
+.badgeAPPROVED {
     background-color: #43b75d;
 }
 
-.badgeDONATED {
-    background-color: #6d717f;
+.badgeCANCELED {
+    background-color: #ee443f;
 }
 
-.primaryButton {
-    width: 100%;
-    padding: 10px 14px;
-    background-color: #0568a6;
-    border: none;
-    border-radius: 8px;
-    color: #ffffff;
-    font-weight: 600;
-    font-size: 0.85rem;
-    cursor: pointer;
+.badgeCOMPLETED {
+    background-color: #078c5b;
 }
 
-.primaryButton:hover {
-    background-color: #045181;
-}
-
-.secondaryActions {
+.actions {
     display: flex;
     gap: 8px;
     width: 100%;
 }
 
-.editButton {
+.approveButton {
     flex: 1;
     padding: 8px 10px;
     background: none;
-    border: 1px solid #0568a6;
+    border: 1px solid #43b75d;
     border-radius: 8px;
-    color: #0568a6;
+    color: #43b75d;
     font-weight: 600;
     font-size: 0.75rem;
     cursor: pointer;
 }
 
-.editButton:hover {
-    background-color: rgba(5, 104, 166, 0.08);
+.approveButton:hover {
+    background-color: rgba(67, 183, 93, 0.08);
 }
 
-.deleteButton {
+.rejectButton {
     flex: 1;
     padding: 8px 10px;
     background: none;
@@ -172,11 +127,12 @@
     cursor: pointer;
 }
 
-.deleteButton:hover {
+.rejectButton:hover {
     background-color: rgba(238, 68, 63, 0.08);
 }
 
-.deleteButton:disabled {
+.approveButton:disabled,
+.rejectButton:disabled {
     opacity: 0.4;
     cursor: not-allowed;
 }

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -19,6 +19,8 @@ import EscolherPerfil from './pages/EscolherPerfil/EscolherPerfil.jsx'
 import { UserLayout } from './layouts/UserLayout.jsx'
 import MinhasSolicitacoes from './pages/user/MinhasSolicitacoes/MinhasSolicitacoes.jsx'
 import MinhasDoacoes from './pages/user/MinhasDoacoes/MinhasDoacoes.jsx'
+import EditarDoacao from './pages/user/EditarDoacao/EditarDoacao.jsx'
+import SolicitacoesDoacao from './pages/user/SolicitacoesDoacao/SolicitacoesDoacao.jsx'
 import UserCatalogo from './pages/user/Catalogo/Catalogo.jsx'
 
 function AppRoutes() {
@@ -48,6 +50,8 @@ function AppRoutes() {
       <Route path="/user" element={<UserLayout />}>
         <Route path="minhas-solicitacoes" element={<MinhasSolicitacoes />} />
         <Route path="minhas-doacoes" element={<MinhasDoacoes />} />
+        <Route path="minhas-doacoes/:id/editar" element={<EditarDoacao />} />
+        <Route path="minhas-doacoes/:id/solicitacoes" element={<SolicitacoesDoacao />} />
         <Route path="catalogo" element={<UserCatalogo />} />
       </Route>
     </Routes>

--- a/src/services/itemsService.js
+++ b/src/services/itemsService.js
@@ -15,3 +15,7 @@ export function createItem(data) {
 export function updateItem(id, data) {
     return api.patch(`/items/${id}`, data).then((response) => response.data);
 }
+
+export function deleteItem(id) {
+    return api.delete(`/items/${id}`).then((response) => response.data);
+}


### PR DESCRIPTION
## Summary
- `Minhas Doações` troca `mockDoacoes` por `listItems()`, filtrando os items do doador logado
- **Editar Item**: nova tela `/user/minhas-doacoes/:id/editar` (form sem o seletor de doador que existe no Admin, aqui o dono é sempre o usuário logado)
- **Ver Solicitações**: nova tela `/user/minhas-doacoes/:id/solicitacoes`, lista os pedidos daquele item com ação de Aprovar/Recusar
- **Excluir Item**: `deleteItem()` novo em `itemsService.js`, com confirmação antes de excluir
- Remove o campo "Localização" do card (não existe esse dado no `Item` do back)

## Known issue
Excluir um item que já tem pedido associado retorna 500 do backend (FK constraint sem tratamento), reportado em [PassaAdiante-NestJS#20](https://github.com/Matheus-Rodrigues-EC/PassaAdiante-NestJS/issues/20). O front já trata isso com uma mensagem de erro genérica, então não quebra a UI, só não é uma mensagem específica pro caso.

## Test plan
- [x] Backend NestJS + `npm run dev`, fluxo `/escolher-perfil` → Usuário comum → Minhas Doações
- [x] Lista mostra só os items do usuário logado
- [x] Editar Item salva as alterações e volta pra listagem
- [x] Ver Solicitações lista os pedidos do item. Aprovar muda o status de verdade
- [x] Excluir Item remove o item de verdade (item sem pedidos associados)
- [x] Sem erros no console

Closes #101